### PR TITLE
Add CircuitPython Library Patching Utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _build
 .env
 env.sh
 *.swp
+.libraries/*

--- a/README.rst
+++ b/README.rst
@@ -70,8 +70,7 @@ for the author.
 
     git config --global user.email "<adabot's email>"
     git config --global user.name "Adafruit Adabot"
-    git config --global credential.helper 'store --file ~/.adabot-git-
-credentials'
+    git config --global credential.helper 'store --file ~/.adabot-git-credentials'
     git push
 
 The git push won't actually push anything but it prompt for the bot's username
@@ -111,6 +110,28 @@ adabot directory and run the following command:
 
 Ensure you have set BOTH the Github access token and Travis token environment
 variables beforehand--see the template-env.sh for the name and where to get tokens.
+
+Applying Patches To All CircuitPython Libraries
+================================================
+To apply a patch to all CircuitPython libraries (only guaranteed for files shared
+among all libraries, such as those included in the cookiecutter (e.g. README.rst,
+.travis.yml, etc), do the following:
+
+1. Apply your update(s) to any library as normal, using `git.commit`.
+2. Create a patch file using [`git format-patch`](https://git-scm.com/docs/git-format-patch).
+There are many techniques to using `git format-patch`; choose the one that makes
+sense for your updates. `--sign-off` is not necessary; adabot will force a
+`--sign-off` when she uses `git am`.
+3. Place the patch file into the `adabot/patches` directory.
+4. Run the patch update script.
+
+
+To run the patch update script you must be inside this cloned adabot directory and
+run the following command:
+
+.. code-block:: shell
+
+    python3 -m adabot.circuitpython_library_patches
 
 Contributing
 ============

--- a/README.rst
+++ b/README.rst
@@ -117,12 +117,12 @@ To apply a patch to all CircuitPython libraries (only guaranteed for files share
 among all libraries, such as those included in the cookiecutter (e.g. README.rst,
 .travis.yml, etc), do the following:
 
-1. Apply your update(s) to any library as normal, using `git.commit`.
-2. Create a patch file using [`git format-patch`](https://git-scm.com/docs/git-format-patch).
+1. Apply your update(s) to any library as normal, using ``git.commit``.
+2. Create a patch file using `git format-patch <https://git-scm.com/docs/git-format-patch>`_.
 There are many techniques to using `git format-patch`; choose the one that makes
-sense for your updates. `--sign-off` is not necessary; adabot will force a
-`--sign-off` when she uses `git am`.
-3. Place the patch file into the `adabot/patches` directory.
+sense for your updates. ``--signoff`` is not necessary; adabot will force a
+``--signoff`` when she uses ``git am``.
+3. Place the patch file into the ``adabot/patches`` directory.
 4. Run the patch update script.
 
 

--- a/README.rst
+++ b/README.rst
@@ -122,8 +122,10 @@ among all libraries, such as those included in the cookiecutter (e.g. README.rst
 There are many techniques to using `git format-patch`; choose the one that makes
 sense for your updates. ``--signoff`` is not necessary; adabot will force a
 ``--signoff`` when she uses ``git am``.
-3. Place the patch file into the ``adabot/patches`` directory.
-4. Run the patch update script.
+3. Place the patch file into the ``adabot/patches`` directory, and ``git commit`` with a
+description of the patch(es).
+4. Push the update to the adabot repository.
+5. Run the patch update script.
 
 
 To run the patch update script you must be inside this cloned adabot directory and
@@ -131,6 +133,9 @@ run the following command:
 
 .. code-block:: shell
 
+    # note: ensure the local clone is current with the github repo that contains the patch(es)
+    # by using git pull before running the script.
+    
     python3 -m adabot.circuitpython_library_patches
 
 Contributing

--- a/adabot/circuitpython_library_patches.py
+++ b/adabot/circuitpython_library_patches.py
@@ -1,70 +1,175 @@
 import json
 import requests
 import os
+import shutil
 import sh
 from sh.contrib import git
-from adabot import circuitpython_bundle as adabot_bundle
 from adabot import circuitpython_libraries as adabot_libraries
-from adabot import github_requests as github
+
 
 working_directory = os.path.abspath(os.getcwd())
+lib_directory = working_directory + "/.libraries/"
+patch_directory = working_directory + "/patches/"
+repos = []
+check_errors = []
+apply_errors = []
+stats = []
 
-repos = [repo["name"] for repo in adabot_libraries.list_repos()]
-#repos = ["Adafruit_CircuitPython_ADS1x15", "Adafruit_CircuitPython_AM2320"]
+def get_repo_list():
+    repo_list = []
+    get_repos = adabot_libraries.list_repos()
+    for repo in get_repos:
+        if not (repo["owner"]["login"] == "sommersoft" and  # test repos
+        #if not (repo["owner"]["login"] == "adafruit" and
+                repo["name"].startswith("Adafruit_CircuitPython")):
+            continue
+        repo_list.append(dict(name=repo["name"], url=repo["clone_url"]))
+
+    return repo_list
 
 def get_patches():
     return_list = []
-    #contents = requests.get("https://api.github.com/repos/adafruit/adabot/contents/adabot")
+    #contents = requests.get("https://api.github.com/repos/adafruit/adabot/contents/patches")
 
     # test contents:
-    contents = requests.get("https://api.github.com/repos/sommersoft/adabot/contents/patches")
-    print(contents.text)
+    contents = requests.get("https://api.github.com/repos/sommersoft/adabot/contents/patches?ref=patches")
     if contents.ok:
-        #patches = [files["name"] for files in contents.json()]
-        print(json.dumps(contents.json(), indent=2), "\n")
         for patch in contents.json():
             patch_name = patch["name"]
             return_list.append(patch_name)
 
     return return_list
 
-def check_patches():
+def apply_patch(repo_directory, patch_filepath, repo, patch):
+    if not os.getcwd() == repo_directory:
+        os.chdir(repo_directory)
+
+    try:
+        git.am("--signoff", patch_filepath)
+    except sh.ErrorReturnCode as Err:
+        #print(".. git.am (patch apply) failed")
+        apply_errors.append(dict(repo_name=repo,
+                               patch_name=patch, error=Err.stderr))
+        return False
+
+    try:
+        git.push("origin", "adabot_patches") # push to branch during testing
+        #git.push()
+    except sh.ErrorReturnCode as Err:
+        #print(".. Push failed:", Err.stderr)
+        apply_errors.append(dict(repo_name=repo,
+                               patch_name=patch, error=Err.stderr))
+        return False
+
+    return True
+
+def check_patches(repo):
+    applied = 0
+    skipped = 0
+    failed = 0
     patches = get_patches()
-    #print(patches, "\n")
 
-    #working_directory = os.path.abspath(os.getcwd())
-    patch_directory = working_directory + "/patches/"
-    for repo in repos:
-        for patch in patches:
-            print("Checking", repo, "for patch:", patch)
-            os.chdir("../" + repo)
-            print("repo dir:", os.getcwd())
-            patch_filepath = patch_directory + patch
-            print("patch dir:", patch_filepath)
-            try:
-                git.apply("--check", "--verbose", patch_filepath)
-                r = True
-            except sh.ErrorReturnCode_1:
-                r = False
-                print("Already Applied", "\n")
-            except sh.ErrorReturnCode_128:
-                r = False
-                print("Errored", "\n")
+    repo_directory = lib_directory + repo["name"]
 
-            if r:
-            #    git.am("--signoff", patch_filepath)
-                print("Applying Patch...", "\n")
+    for patch in patches:
+        #print(". Checking", repo["name"], "for patch:", patch)
+        try:
+            os.chdir(lib_directory)
+        except FileNotFoundError:
+            os.mkdir(lib_directory)
+            os.chdir(lib_directory)
 
+        try:
+            git.clone(repo["url"])
+        except sh.ErrorReturnCode_128 as Err:
+            if b"already exists" in Err.stderr:
+                pass
+            else: # erring on the side of caution here
+                raise RuntimeError(Err.stderr)
+        os.chdir(repo_directory)
+
+        # delete this try block after testing
+        try:
+            git.checkout("-b", "adabot_patches")
+        except sh.ErrorReturnCode as Err:
+            if not b'already exists' in Err.stderr:
+                raise RuntimeError(Err.stderr)
+        # ^^ delete this try block after testing ^^
+
+        patch_filepath = patch_directory + patch
+        #print("patch dir:", patch_filepath)
+        try:
+            git.apply("--check", patch_filepath)
+            run_apply = True
+        except sh.ErrorReturnCode_1:
+            run_apply = False
+            #print("..", patch, "Already Applied")
+            skipped += 1
+        except sh.ErrorReturnCode_128 as Err:
+            run_apply = False
+            #print(".. Patch check failed")
+            failed += 1
+            check_errors.append(dict(repo_name=repo["name"],
+                               patch_name=patch, error=Err.stderr))
+
+        if run_apply:
+            #print(".. Applying Patch To:", repo)
+            # this is failing
+            result = apply_patch(repo_directory, patch_filepath, repo["name"], patch)
+            if result:
+                #print("..", patch, "Applied!")
+                applied += 1
+            else:
+                #print("..", patch, "Failed!")
+                failed += 1
+
+    return [applied, skipped, failed]
 
 if __name__ == "__main__":
-    print(".... Beginning Patch Updates ....\n")
-    print("Working directory:", working_directory)
-    os.chdir("..")
-    directory = os.path.abspath(".bundles")
-    print("Bundles directory:", directory)
-    #for bundle in adabot_bundle.bundles:
-    #    bundle_path = os.path.join(directory, bundle)
-    #    try:
-    #        fetch_bundle(bundle, bundle_path)
+    print(".... Beginning Patch Updates ....")
+    print(".... Working directory:", working_directory)
+    print(".... Library directory:", lib_directory)
+    print(".... Patches directory:", patch_directory)
 
-    check_patches()
+    check_errors = []
+    apply_errors = []
+    stats = [0, 0, 0]
+
+    print(".... Deleting any previously cloned libraries")
+    libs = os.listdir(path=lib_directory)
+    for lib in libs:
+        #print("..... Deleting:", lib_directory + lib)
+        shutil.rmtree(lib_directory + lib)
+        
+
+    repos = get_repo_list()
+    run_limit = 5 # delete run_limit after testing
+    i = 0 # delete run_limit after testing
+    for repo in repos:
+        results = check_patches(repo)
+        for k in range(len(stats)):
+            stats[k] += results[k]
+        # delete run_limit after testing
+        i += 1
+        if i >= run_limit:
+            break
+        # ^^ delete run_limit after testing ^^
+
+    print(".... Patch Updates Completed ....")
+    print(".... Patches Applied:", stats[0])
+    print(".... Patches Skipped:", stats[1])
+    print(".... Patches Failed:", stats[2], "\n")
+    print(".... Patch Check Failure Report ....")
+    if len(check_errors) > 0:
+        for error, _ in check_errors:
+            print(">>", error)
+    else:
+        print("No Failures")
+    print("\n")
+    print(".... Patch Apply Failure Report ....")
+    if len(apply_errors) > 0:
+        for error in apply_errors:
+            print(">>", error)
+    else:
+        print("No Failures")
+        

--- a/adabot/circuitpython_library_patches.py
+++ b/adabot/circuitpython_library_patches.py
@@ -1,0 +1,70 @@
+import json
+import requests
+import os
+import sh
+from sh.contrib import git
+from adabot import circuitpython_bundle as adabot_bundle
+from adabot import circuitpython_libraries as adabot_libraries
+from adabot import github_requests as github
+
+working_directory = os.path.abspath(os.getcwd())
+
+repos = [repo["name"] for repo in adabot_libraries.list_repos()]
+#repos = ["Adafruit_CircuitPython_ADS1x15", "Adafruit_CircuitPython_AM2320"]
+
+def get_patches():
+    return_list = []
+    #contents = requests.get("https://api.github.com/repos/adafruit/adabot/contents/adabot")
+
+    # test contents:
+    contents = requests.get("https://api.github.com/repos/sommersoft/adabot/contents/patches")
+    print(contents.text)
+    if contents.ok:
+        #patches = [files["name"] for files in contents.json()]
+        print(json.dumps(contents.json(), indent=2), "\n")
+        for patch in contents.json():
+            patch_name = patch["name"]
+            return_list.append(patch_name)
+
+    return return_list
+
+def check_patches():
+    patches = get_patches()
+    #print(patches, "\n")
+
+    #working_directory = os.path.abspath(os.getcwd())
+    patch_directory = working_directory + "/patches/"
+    for repo in repos:
+        for patch in patches:
+            print("Checking", repo, "for patch:", patch)
+            os.chdir("../" + repo)
+            print("repo dir:", os.getcwd())
+            patch_filepath = patch_directory + patch
+            print("patch dir:", patch_filepath)
+            try:
+                git.apply("--check", "--verbose", patch_filepath)
+                r = True
+            except sh.ErrorReturnCode_1:
+                r = False
+                print("Already Applied", "\n")
+            except sh.ErrorReturnCode_128:
+                r = False
+                print("Errored", "\n")
+
+            if r:
+            #    git.am("--signoff", patch_filepath)
+                print("Applying Patch...", "\n")
+
+
+if __name__ == "__main__":
+    print(".... Beginning Patch Updates ....\n")
+    print("Working directory:", working_directory)
+    os.chdir("..")
+    directory = os.path.abspath(".bundles")
+    print("Bundles directory:", directory)
+    #for bundle in adabot_bundle.bundles:
+    #    bundle_path = os.path.join(directory, bundle)
+    #    try:
+    #        fetch_bundle(bundle, bundle_path)
+
+    check_patches()

--- a/patches/0001-updated-CoC.patch
+++ b/patches/0001-updated-CoC.patch
@@ -1,0 +1,180 @@
+From b7148a7dde837a215d582856f038e81c441b1c0d Mon Sep 17 00:00:00 2001
+From: sommersoft <sommersoft@gmail.com>
+Date: Wed, 11 Jul 2018 09:44:39 -0500
+Subject: [PATCH] updated CoC
+
+---
+ CODE_OF_CONDUCT.md | 123 ++++++++++++++++++++++++++++++++++++++---------------
+ 1 file changed, 88 insertions(+), 35 deletions(-)
+
+diff --git a/CODE_OF_CONDUCT.md b/CODE_OF_CONDUCT.md
+index 1617586..a9b258d 100644
+--- a/CODE_OF_CONDUCT.md
++++ b/CODE_OF_CONDUCT.md
+@@ -1,74 +1,127 @@
+-# Contributor Covenant Code of Conduct
++# Adafruit Community Code of Conduct
+ 
+ ## Our Pledge
+ 
+ In the interest of fostering an open and welcoming environment, we as
+-contributors and maintainers pledge to making participation in our project and
++contributors and leaders pledge to making participation in our project and
+ our community a harassment-free experience for everyone, regardless of age, body
+-size, disability, ethnicity, gender identity and expression, level of experience,
+-nationality, personal appearance, race, religion, or sexual identity and
+-orientation.
++size, disability, ethnicity, gender identity and expression, level or type of
++experience, education, socio-economic status, nationality, personal appearance,
++race, religion, or sexual identity and orientation.
+ 
+ ## Our Standards
+ 
++We are committed to providing a friendly, safe and welcoming environment for
++all.
++
+ Examples of behavior that contributes to creating a positive environment
+ include:
+ 
++* Be kind and courteous to others
+ * Using welcoming and inclusive language
+ * Being respectful of differing viewpoints and experiences
++* Collaborating with other community members
+ * Gracefully accepting constructive criticism
+ * Focusing on what is best for the community
+ * Showing empathy towards other community members
+ 
+ Examples of unacceptable behavior by participants include:
+ 
+-* The use of sexualized language or imagery and unwelcome sexual attention or
+-advances
++* The use of sexualized language or imagery and sexual attention or advances
++* The use of inappropriate images, including in a community member's avatar
++* The use of inappropriate language, including in a community member's nickname
++* Any spamming, flaming, baiting or other attention-stealing behavior
++* Excessive or unwelcome helping; answering outside the scope of the question
++  asked
+ * Trolling, insulting/derogatory comments, and personal or political attacks
+ * Public or private harassment
+ * Publishing others' private information, such as a physical or electronic
+   address, without explicit permission
+-* Other conduct which could reasonably be considered inappropriate in a
+-  professional setting
++* Other conduct which could reasonably be considered inappropriate
++
++The goal of the standards and moderation guidelines outlined here is to build
++and maintain a respectful community. We ask that you don’t just aim to be
++"technically unimpeachable", but rather try to be your best self. 
++
++We value many things beyond technical expertise, including collaboration and
++supporting others within our community. Providing a positive experience for
++other community members can have a much more significant impact than simply
++providing the correct answer.
+ 
+ ## Our Responsibilities
+ 
+-Project maintainers are responsible for clarifying the standards of acceptable
++Project leaders are responsible for clarifying the standards of acceptable
+ behavior and are expected to take appropriate and fair corrective action in
+ response to any instances of unacceptable behavior.
+ 
+-Project maintainers have the right and responsibility to remove, edit, or
+-reject comments, commits, code, wiki edits, issues, and other contributions
++Project leaders have the right and responsibility to remove, edit, or
++reject messages, comments, commits, code, issues, and other contributions
+ that are not aligned to this Code of Conduct, or to ban temporarily or
+-permanently any contributor for other behaviors that they deem inappropriate,
+-threatening, offensive, or harmful.
++permanently any community member for other behaviors that they deem
++inappropriate, threatening, offensive, or harmful.
+ 
+-## Scope
++## Moderation
+ 
+-This Code of Conduct applies both within project spaces and in public spaces
+-when an individual is representing the project or its community. Examples of
+-representing a project or community include using an official project e-mail
+-address, posting via an official social media account, or acting as an appointed
+-representative at an online or offline event. Representation of a project may be
+-further defined and clarified by project maintainers.
++Instances of behaviors that violate the Adafruit Community Code of Conduct
++may be reported by any member of the community. Community members are
++encouraged to report these situations, including situations they witness
++involving other community members.
++
++You may report in the following ways:
++
++In any situation, you may send an email to <support@adafruit.com>.
+ 
+-## Enforcement
++On the Adafruit Discord, you may send an open message from any channel
++to all Community Helpers by tagging @community helpers. You may also send an
++open message from any channel, or a direct message to @kattni#1507,
++@tannewt#4653, @Dan Halbert#1614, @cater#2442, @sommersoft#0222, or
++@Andon#8175.
+ 
+-Instances of abusive, harassing, or otherwise unacceptable behavior may be
+-reported by contacting the project team at support@adafruit.com. All
+-complaints will be reviewed and investigated and will result in a response that
+-is deemed necessary and appropriate to the circumstances. The project team is
+-obligated to maintain confidentiality with regard to the reporter of an incident.
+-Further details of specific enforcement policies may be posted separately.
++Email and direct message reports will be kept confidential.
+ 
+-Project maintainers who do not follow or enforce the Code of Conduct in good
+-faith may face temporary or permanent repercussions as determined by other
+-members of the project's leadership.
++In situations on Discord where the issue is particularly egregious, possibly
++illegal, requires immediate action, or violates the Discord terms of service,
++you should also report the message directly to Discord.
++
++These are the steps for upholding our community’s standards of conduct.
++
++1. Any member of the community may report any situation that violates the
++Adafruit Community Code of Conduct. All reports will be reviewed and
++investigated.
++2. If the behavior is an egregious violation, the community member who
++committed the violation may be banned immediately, without warning.
++3. Otherwise, moderators will first respond to such behavior with a warning.
++4. Moderators follow a soft "three strikes" policy - the community member may
++be given another chance, if they are receptive to the warning and change their
++behavior.
++5. If the community member is unreceptive or unreasonable when warned by a
++moderator, or the warning goes unheeded, they may be banned for a first or
++second offense. Repeated offenses will result in the community member being
++banned.
++
++## Scope
++
++This Code of Conduct and the enforcement policies listed above apply to all
++Adafruit Community venues. This includes but is not limited to any community
++spaces (both public and private), the entire Adafruit Discord server, and
++Adafruit GitHub repositories. Examples of Adafruit Community spaces include
++but are not limited to meet-ups, audio chats on the Adafruit Discord, or
++interaction at a conference.
++
++This Code of Conduct applies both within project spaces and in public spaces
++when an individual is representing the project or its community. As a community
++member, you are representing our community, and are expected to behave
++accordingly.
+ 
+ ## Attribution
+ 
+-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+-available at [http://contributor-covenant.org/version/1/4][version]
++This Code of Conduct is adapted from the [Contributor Covenant][homepage],
++version 1.4, available at
++<https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>,
++and the [Rust Code of Conduct](https://www.rust-lang.org/en-US/conduct.html).
+ 
+-[homepage]: http://contributor-covenant.org
+-[version]: http://contributor-covenant.org/version/1/4/
++For other projects adopting the Adafruit Community Code of
++Conduct, please contact the maintainers of those projects for enforcement.
++If you wish to use this code of conduct for your own project, consider
++explicitly mentioning your moderation policy or making a copy with your
++own moderation policy so as to avoid confusion.
+\ No newline at end of file
+-- 
+2.15.1.windows.2
+


### PR DESCRIPTION
This will apply any patch that exists in the `patches` directory to all CircuitPython Libraries (Adafruit Bundle only; could probably extend to the Community Bundle would just need to tweak the search for library repos).

Patch files are created using `git format-patch`, and applied with `git am`. See updated README.rst.

This initial PR keeps my testing setup, uses my GitHub forks of the libraries, and pushes to branches. Final settings/values are commented out, and any extra bits for the test setup are contained in comment blocks.

Here are sample outputs. I thought about dropping log files vs printing to screen; would be an easy addition.

Good Run:
```
(.env) vagrant@ubuntu-xenial:~/source/adabot$ python3 -m adabot.circuitpython_library_patches
.... Beginning Patch Updates ....
.... Working directory: /home/vagrant/source/adabot
.... Library directory: /home/vagrant/source/adabot/.libraries/
.... Patches directory: /home/vagrant/source/adabot/patches/
.... Deleting any previously cloned libraries
.... Patch Updates Completed ....
.... Patches Applied: 5
.... Patches Skipped: 0
.... Patches Failed: 0

.... Patch Check Failure Report ....
No Failures

.... Patch Apply Failure Report ....
No Failures
```

Run with failures:
```
(.env) vagrant@ubuntu-xenial:~/source/adabot$ python3 -m adabot.circuitpython_library_patches
.... Beginning Patch Updates ....
.... Working directory: /home/vagrant/source/adabot
.... Library directory: /home/vagrant/source/adabot/.libraries/
.... Patches directory: /home/vagrant/source/adabot/patches/
.... Deleting any previously cloned libraries
.... Patch Updates Completed ....
.... Patches Applied: 0
.... Patches Skipped: 0
.... Patches Failed: 5

.... Patch Check Failure Report ....
No Failures

.... Patch Apply Failure Report ....
>> {'repo_name': 'Adafruit_CircuitPython_SSD1306', 'patch_name': '0001-updated-CoC.patch', 'error': b"To https://github.com/sommersoft/Adafruit_CircuitPython_SSD1306.git\n ! [rejected]        adabot_patches -> adabot_patches (non-fast-forward)\nerror: failed to push some refs to 'https://github.com/sommersoft/Adafruit_CircuitPython_SSD1306.git'\nhint: Updates were rejected because the tip of your current branch is behind\nhint: its remote counterpart. Integrate the remote changes (e.g.\nhint: 'git pull ...') before pushing again.\nhint: See the 'Note about fast-forwards' in 'git push --help' for details.\n"}
>> {'repo_name': 'Adafruit_CircuitPython_Thermal_Printer', 'patch_name': '0001-updated-CoC.patch', 'error': b"To https://github.com/sommersoft/Adafruit_CircuitPython_Thermal_Printer.git\n ! [rejected]        adabot_patches -> adabot_patches (non-fast-forward)\nerror: failed to push some refs to 'https://github.com/sommersoft/Adafruit_CircuitPython_Thermal_Printer.git'\nhint: Updates were rejected because the tip of your current branch is behind\nhint: its remote counterpart. Integrate the remote changes (e.g.\nhint: 'git pull ...') before pushing again.\nhint: See the 'Note about fast-forwards' in 'git push --help' for details.\n"}
>> {'repo_name': 'Adafruit_CircuitPython_Thermistor', 'patch_name': '0001-updated-CoC.patch', 'error': b"To https://github.com/sommersoft/Adafruit_CircuitPython_Thermistor.git\n ! [rejected]        adabot_patches -> adabot_patches (non-fast-forward)\nerror: failed to push some refs to 'https://github.com/sommersoft/Adafruit_CircuitPython_Thermistor.git'\nhint: Updates were rejected because the tip of your current branch is behind\nhint: its remote counterpart. Integrate the remote changes (e.g.\nhint: 'git pull ...') before pushing again.\nhint: See the 'Note about fast-forwards' in 'git push --help' for details.\n"}
>> {'repo_name': 'Adafruit_CircuitPython_TLC5947', 'patch_name': '0001-updated-CoC.patch', 'error': b"To https://github.com/sommersoft/Adafruit_CircuitPython_TLC5947.git\n ! [rejected]        adabot_patches -> adabot_patches (non-fast-forward)\nerror: failed to push some refs to 'https://github.com/sommersoft/Adafruit_CircuitPython_TLC5947.git'\nhint: Updates were rejected because the tip of your current branch is behind\nhint: its remote counterpart. Integrate the remote changes (e.g.\nhint: 'git pull ...') before pushing again.\nhint: See the 'Note about fast-forwards' in 'git push --help' for details.\n"}
>> {'repo_name': 'Adafruit_CircuitPython_TLC59711', 'patch_name': '0001-updated-CoC.patch', 'error': b"To https://github.com/sommersoft/Adafruit_CircuitPython_TLC59711.git\n ! [rejected]        adabot_patches -> adabot_patches (non-fast-forward)\nerror: failed to push some refs to 'https://github.com/sommersoft/Adafruit_CircuitPython_TLC59711.git'\nhint: Updates were rejected because the tip of your current branch is behind\nhint: its remote counterpart. Integrate the remote changes (e.g.\nhint: 'git pull ...') before pushing again.\nhint: See the 'Note about fast-forwards' in 'git push --help' for details.\n"}
```