### PR TITLE
Patch Script Fix & New Patch For pylint

### DIFF
--- a/adabot/circuitpython_library_patches.py
+++ b/adabot/circuitpython_library_patches.py
@@ -131,13 +131,16 @@ if __name__ == "__main__":
     stats = [0, 0, 0]
 
     print(".... Deleting any previously cloned libraries")
-    libs = os.listdir(path=lib_directory)
-    for lib in libs:
-        shutil.rmtree(lib_directory + lib)
-        
+    try:
+        libs = os.listdir(path=lib_directory)
+        for lib in libs:
+            shutil.rmtree(lib_directory + lib)
+    except FileNotFoundError:
+        pass    
 
     repos = get_repo_list()
     print(".... Running Patch Checks On", len(repos), "Repos ....")
+
     for repo in repos:
         results = check_patches(repo)
         for k in range(len(stats)):

--- a/patches/0001-force-Travis-to-use-pylint-version-1.9.2-to-avoid-ne.patch
+++ b/patches/0001-force-Travis-to-use-pylint-version-1.9.2-to-avoid-ne.patch
@@ -1,0 +1,27 @@
+From fda6742201bd78097639fc59dff79ccf9204d973 Mon Sep 17 00:00:00 2001
+From: sommersoft <sommersoft@gmail.com>
+Date: Fri, 27 Jul 2018 17:08:57 -0500
+Subject: [PATCH] force Travis to use pylint version 1.9.2 to avoid new version
+ 2.0 rules.
+
+---
+ .travis.yml | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/.travis.yml b/.travis.yml
+index b49e1f0..98b1f8b 100644
+--- a/.travis.yml
++++ b/.travis.yml
+@@ -23,7 +23,8 @@ deploy:
+     tags: true
+ 
+ install:
+-  - pip install pylint circuitpython-build-tools Sphinx sphinx-rtd-theme
++  - pip install circuitpython-build-tools Sphinx sphinx-rtd-theme
++  - pip install --force-reinstall pylint==1.9.2
+ 
+ script:
+   - pylint adafruit_thermistor.py
+-- 
+2.15.1.windows.2
+


### PR DESCRIPTION
- Patch Script Fix: added exception handling for `__main__` in case the `.libraries` folder doesn't exist yet.

- New Patch: updates `.travis.yml` to force use of pylint v1.9.2; avoids applying new rules in pylint v2.0.