### PR TITLE
Validate Release State and Upgrade 'requests' Module

### DIFF
--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -41,8 +41,6 @@ cmd_line_parser.add_argument("-v", "--verbose", help="Set the level of verbosity
                              " Zero is off; One is on (default).", type=int, default=1, dest="verbose", choices=[0,1])
 cmd_line_parser.add_argument("-e", "--error_depth", help="Set the threshold for outputting an error list. Default is 5.",
                              dest="error_depth", type=int, default=5, metavar="n")
-#cmd_line_parser.add_argument("-t", "--token", help="Supply a GitHub token to use for activating Travis.",
-#                             dest=gh_token, metavar="<GITHUB_TOKEN>")
 cmd_line_parser.add_argument("-t", "--token", help="Prompt for a GitHub token to use for activating Travis.",
                              dest="gh_token", action="store_true")
 
@@ -603,7 +601,6 @@ def validate_travis(repo):
         found_token = found_token or var["name"] == "GITHUB_TOKEN"
     ok = True
     if not found_token:
-        #if github_token is None:
         if not github_token:
             return [ERROR_TRAVIS_GITHUB_TOKEN]
         else:
@@ -1037,7 +1034,6 @@ output_filename = None
 file_data = []
 # Verbosity level
 verbosity = 1
-#github_token = None
 github_token = False
 
 if __name__ == "__main__":

--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -238,7 +238,7 @@ def is_repo_in_bundle(repo_clone_url, bundle_submodules):
         # URLs matched so now check if the submodule is placed in the libraries
         # subfolder of the bundle.  Just look at the path from the submodule
         # state.
-        if variables.get('path', '',).startswith('libraries/'):
+        if variables.get('path', '').startswith('libraries/'):
             # Success! Found the repo as a submodule of the libraries folder
             # in the bundle.
             return True

--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -190,7 +190,8 @@ def get_bundle_submodules():
     # Assume the bundle repository is public and get the .gitmodules file
     # without any authentication or Github API usage.  Also assumes the
     # master branch of the bundle is the canonical source of the bundle release.
-    result = requests.get('https://raw.githubusercontent.com/adafruit/Adafruit_CircuitPython_Bundle/master/.gitmodules')
+    result = requests.get('https://raw.githubusercontent.com/adafruit/Adafruit_CircuitPython_Bundle/master/.gitmodules',
+                          timeout=5)
     if result.status_code != 200:
         output_handler("Failed to access bundle .gitmodules file from GitHub!", quiet=True)
         raise RuntimeError('Failed to access bundle .gitmodules file from GitHub!')
@@ -239,7 +240,7 @@ def is_repo_in_bundle(repo_clone_url, bundle_submodules):
         # URLs matched so now check if the submodule is placed in the libraries
         # subfolder of the bundle.  Just look at the path from the submodule
         # state.
-        if variables.get('path', '').startswith('libraries/'):
+        if variables.get('path', '',).startswith('libraries/'):
             # Success! Found the repo as a submodule of the libraries folder
             # in the bundle.
             return True
@@ -256,7 +257,8 @@ def list_repos():
                         params={"q":"Adafruit_CircuitPython in:name fork:true",
                                 "per_page": 100,
                                 "sort": "updated",
-                                "order": "asc"})
+                                "order": "asc"},
+                        timeout=5)
     while result.ok:
         links = result.headers["Link"]
         #repos.extend(result.json()["items"]) # uncomment and comment below, to include all forks
@@ -274,7 +276,7 @@ def list_repos():
         if not next_url:
             break
         # Subsequent links have our access token already so we use requests directly.
-        result = requests.get(link)
+        result = requests.get(link, timeout=5)
 
     return repos
 
@@ -287,7 +289,7 @@ def validate_repo_state(repo):
     if not (repo["owner"]["login"] == "adafruit" and
             repo["name"].startswith("Adafruit_CircuitPython")):
         return []
-    full_repo = github.get("/repos/" + repo["full_name"])
+    full_repo = github.get("/repos/" + repo["full_name"], timeout=5)
     if not full_repo.ok:
         return [ERROR_UNABLE_PULL_REPO_DETAILS]
     full_repo = full_repo.json()
@@ -315,10 +317,10 @@ def validate_release_state(repo):
     if not (repo["owner"]["login"] == "adafruit" and
             repo["name"].startswith("Adafruit_CircuitPython")):
         return []
-    repo_last_release = github.get("/repos/" + repo["full_name"] + "/releases/latest")
+
+    repo_last_release = github.get("/repos/" + repo["full_name"] + "/releases/latest", timeout=5)
     if not repo_last_release.ok:
         return [ERROR_GITHUB_NO_RELEASE]
-    params = {"since": str(repo_last_release.json()["published_at"])}
     repo_release_json = repo_last_release.json()
     if "tag_name" in repo_release_json:
         tag_name = repo_release_json["tag_name"]
@@ -349,7 +351,7 @@ def validate_release_state(repo):
 
 def validate_readme(repo, download_url):
     # We use requests because file contents are hosted by githubusercontent.com, not the API domain.
-    contents = requests.get(download_url)
+    contents = requests.get(download_url, timeout=5)
     if not contents.ok:
         return [ERROR_README_DOWNLOAD_FAILED]
 
@@ -390,7 +392,7 @@ def validate_py_for_ustruct(repo, download_url):
         used with NO "import struct" generate an error.
     """
     # We use requests because file contents are hosted by githubusercontent.com, not the API domain.
-    contents = requests.get(download_url)
+    contents = requests.get(download_url, timeout=5)
     if not contents.ok:
         return [ERROR_PYFILE_DOWNLOAD_FAILED]
 
@@ -408,7 +410,7 @@ def validate_travis_yml(repo, travis_yml_file_info):
     """Check size and then check pypi compatibility.
     """
     download_url = travis_yml_file_info["download_url"]
-    contents = requests.get(download_url)
+    contents = requests.get(download_url, timeout=5)
     if not contents.ok:
         return [ERROR_PYFILE_DOWNLOAD_FAILED]
 
@@ -439,7 +441,7 @@ def validate_setup_py(repo, file_info):
     """Check setup.py for pypi compatibility
     """
     download_url = file_info["download_url"]
-    contents = requests.get(download_url)
+    contents = requests.get(download_url, timeout=5)
     if not contents.ok:
         return [ERROR_PYFILE_DOWNLOAD_FAILED]
 
@@ -452,7 +454,7 @@ def validate_requirements_txt(repo, file_info):
     """Check requirements.txt for pypi compatibility
     """
     download_url = file_info["download_url"]
-    contents = requests.get(download_url)
+    contents = requests.get(download_url, timeout=5)
     if not contents.ok:
         return [ERROR_PYFILE_DOWNLOAD_FAILED]
 
@@ -476,7 +478,7 @@ def validate_contents(repo):
     if repo["name"] == BUNDLE_REPO_NAME:
         return []
 
-    content_list = github.get("/repos/" + repo["full_name"] + "/contents/")
+    content_list = github.get("/repos/" + repo["full_name"] + "/contents/", timeout=5)
     if not content_list.ok:
         return [ERROR_UNABLE_PULL_REPO_CONTENTS]
 
@@ -533,7 +535,7 @@ def validate_contents(repo):
     dirs = [x["name"] for x in content_list if x["type"] == "dir"]
     if "examples" in dirs:
         # check for at least on .py file
-        examples_list = github.get("/repos/" + repo["full_name"] + "/contents/examples")
+        examples_list = github.get("/repos/" + repo["full_name"] + "/contents/examples", timeout=5)
         if not examples_list.ok:
             errors.append(ERROR_UNABLE_PULL_REPO_EXAMPLES)
         examples_list = examples_list.json()
@@ -554,7 +556,7 @@ def validate_contents(repo):
     for adir in dirs:
         if re_str.fullmatch(adir):
             # retrieve the files in that directory
-            dir_file_list = github.get("/repos/" + repo["full_name"] + "/contents/" + adir)
+            dir_file_list = github.get("/repos/" + repo["full_name"] + "/contents/" + adir, timeout=5)
             if not dir_file_list.ok:
                 errors.append(ERROR_UNABLE_PULL_REPO_DIR)
             dir_file_list = dir_file_list.json()
@@ -577,7 +579,7 @@ def validate_travis(repo):
             repo["name"].startswith("Adafruit_CircuitPython")):
         return []
     repo_url = "/repo/" + repo["owner"]["login"] + "%2F" + repo["name"]
-    result = travis.get(repo_url)
+    result = travis.get(repo_url, timeout=5)
     if not result.ok:
         #print(result, result.request.url, result.request.headers)
         #print(result.text)
@@ -590,7 +592,7 @@ def validate_travis(repo):
             #output_handler("{} {}".format(activate, activate.text))
             return [ERROR_ENABLE_TRAVIS]
 
-    env_variables = travis.get(repo_url + "/env_vars")
+    env_variables = travis.get(repo_url + "/env_vars", timeout=5)
     if not env_variables.ok:
         #print(env_variables, env_variables.text)
         #print(env_variables.request.headers)
@@ -608,7 +610,7 @@ def validate_travis(repo):
             global full_auth
             if not full_auth:
                 #github_user = github_token
-                github_user = github.get("/user").json()
+                github_user = github.get("/user", timeout=5).json()
                 password = input("Password for " + github_user["login"] + ": ")
                 full_auth = (github_user["login"], password.strip())
             if not full_auth:
@@ -645,7 +647,8 @@ def validate_readthedocs(repo):
         return []
     global rtd_subprojects
     if not rtd_subprojects:
-        rtd_response = requests.get("https://readthedocs.org/api/v2/project/74557/subprojects/")
+        rtd_response = requests.get("https://readthedocs.org/api/v2/project/74557/subprojects/",
+                                    timeout=5)
         if not rtd_response.ok:
             return [ERROR_RTD_SUBPROJECT_FAILED]
         rtd_subprojects = {}
@@ -663,12 +666,13 @@ def validate_readthedocs(repo):
         errors.append(ERROR_RTD_ADABOT_MISSING)
 
     valid_versions = requests.get(
-        "https://readthedocs.org/api/v2/project/{}/valid_versions/".format(subproject["id"]))
+        "https://readthedocs.org/api/v2/project/{}/valid_versions/".format(subproject["id"]),
+        timeout=5)
     if not valid_versions.ok:
         errors.append(ERROR_RTD_VALID_VERSIONS_FAILED)
     else:
         valid_versions = valid_versions.json()
-        latest_release = github.get("/repos/{}/releases/latest".format(repo["full_name"]))
+        latest_release = github.get("/repos/{}/releases/latest".format(repo["full_name"]), timeout=5)
         if not latest_release.ok:
             errors.append(ERROR_GITHUB_RELEASE_FAILED)
         else:
@@ -678,7 +682,8 @@ def validate_readthedocs(repo):
     # There is no API which gives access to a list of builds for a project so we parse the html
     # webpage.
     builds_webpage = requests.get(
-        "https://readthedocs.org/projects/{}/builds/".format(subproject["slug"]))
+        "https://readthedocs.org/projects/{}/builds/".format(subproject["slug"]),
+        timeout=5)
     if not builds_webpage.ok:
         errors.append(ERROR_RTD_FAILED_TO_LOAD_BUILDS)
     else:
@@ -689,7 +694,8 @@ def validate_readthedocs(repo):
             # latest" found. Its in the page after the build id.
             if "version latest" in line:
                 break
-        build_info = requests.get("https://readthedocs.org/api/v2/build/{}/".format(build_id))
+        build_info = requests.get("https://readthedocs.org/api/v2/build/{}/".format(build_id),
+                                  timeout=5)
         if not build_info.ok:
             errors.append(ERROR_RTD_FAILED_TO_LOAD_BUILD_INFO)
         else:
@@ -729,7 +735,8 @@ def validate_core_driver_page(repo):
         return []
     global core_driver_page
     if not core_driver_page:
-        driver_page = requests.get("https://raw.githubusercontent.com/adafruit/circuitpython/master/docs/drivers.rst")
+        driver_page = requests.get("https://raw.githubusercontent.com/adafruit/circuitpython/master/docs/drivers.rst",
+                                   timeout=5)
         if not driver_page.ok:
             return [ERROR_DRIVERS_PAGE_DOWNLOAD_FAILED]
         core_driver_page = driver_page.text
@@ -759,14 +766,14 @@ def gather_insights(repo, insights, since):
     params = {"sort": "updated",
               "state": "all",
               "since": str(since)}
-    response = github.get("/repos/" + repo["full_name"] + "/issues", params=params)
+    response = github.get("/repos/" + repo["full_name"] + "/issues", params=params, timeout=5)
     if not response.ok:
         output_handler("Insights request failed: {}".format(repo["full_name"]))
     issues = response.json()
     for issue in issues:
         created = datetime.datetime.strptime(issue["created_at"], "%Y-%m-%dT%H:%M:%SZ")
         if "pull_request" in issue:
-            pr_info = github.get(issue["pull_request"]["url"])
+            pr_info = github.get(issue["pull_request"]["url"], timeout=5)
             pr_info = pr_info.json()
             if issue["state"] == "open":
                 if created > since:
@@ -781,7 +788,7 @@ def gather_insights(repo, insights, since):
                 else:
                     insights["closed_prs"] += 1
         else:
-            issue_info = github.get(issue["url"])
+            issue_info = github.get(issue["url"], timeout=5)
             issue_info = issue_info.json()
             if issue["state"] == "open":
                 if created > since:
@@ -793,7 +800,7 @@ def gather_insights(repo, insights, since):
                 insights["issue_closers"].add(issue_info["closed_by"]["login"])
 
     params = {"state": "open", "per_page": 100}
-    response = github.get("/repos/" + repo["full_name"] + "/issues", params=params)
+    response = github.get("/repos/" + repo["full_name"] + "/issues", params=params, timeout=5)
     if not response.ok:
         output_handler("Issues request failed: {}".format(repo["full_name"]))
     issues = response.json()
@@ -807,7 +814,7 @@ def gather_insights(repo, insights, since):
 def repo_is_on_pypi(repo):
     """returns True when the provided repository is in pypi"""
     is_on = False
-    the_page = pypi.get("/pypi/"+repo["name"]+"/json")
+    the_page = pypi.get("/pypi/"+repo["name"]+"/json", timeout=5)
     if the_page and the_page.status_code == 200:
         is_on = True
 
@@ -826,7 +833,7 @@ def validate_in_pypi(repo):
 
 def run_library_checks():
     """runs the various library checking functions"""
-    pylint_info = pypi.get("/pypi/pylint/json")
+    pylint_info = pypi.get("/pypi/pylint/json", timeout=5)
     if pylint_info and pylint_info.ok:
         latest_pylint = pylint_info.json()["info"]["version"]
     output_handler("Latest pylint is: {}".format(latest_pylint))
@@ -836,9 +843,9 @@ def run_library_checks():
     global bundle_submodules
     bundle_submodules = get_bundle_submodules()
     output_handler("Found {} submodules in the bundle.".format(len(bundle_submodules)))
-    github_user = github.get("/user").json()
+    github_user = github.get("/user", timeout=5).json()
     output_handler("Running GitHub checks as " + github_user["login"])
-    travis_user = travis.get("/user").json()
+    travis_user = travis.get("/user", timeout=5).json()
     output_handler("Running Travis checks as " + travis_user["login"])
     need_work = 0
     lib_insights = {
@@ -942,7 +949,7 @@ def output_handler(message="", quiet=False):
 
 def print_circuitpython_download_stats():
     """Gather and report analytics on the main CircuitPython repository."""
-    response = github.get("/repos/adafruit/circuitpython/releases")
+    response = github.get("/repos/adafruit/circuitpython/releases", timeout=5)
     if not response.ok:
         output_handler("Core CircuitPython GitHub analytics request failed.")
     releases = response.json()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ certifi==2017.11.5
 chardet==3.0.4
 idna==2.6
 redis==2.10.6
-requests==2.18.4
+requests==2.20.0
 sh==1.12.14
 urllib3==1.22


### PR DESCRIPTION
- Fixes #18.

- Also updates `requests` module to v2.20.0, as installed by requirements.txt. This is due to a vulnerability fix ([CVE-2018-18074](http://docs.python-requests.org/en/latest/community/updates/#id1)).

  While testing this upgrade on my computer, I experienced endless hangs. After an arduous search, I came across this note on [timeouts](http://docs.python-requests.org/en/master/user/quickstart/#timeouts), which at least allowed requests to progress. I set `timeouts = 5`; anything below that usually resulted in timeout errors.