### PR TITLE
Run Adabot On Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+# TravisCI config for running Adabot on autopilot.
+dist: trusty
+sudo: false
+language: python
+python:
+  - "3.6"
+cache:
+  pip: true
+
+env:
+    # LIB_CHECK_FILE is for circuitpython_libraries.py output
+    # LIB_DL_STATS_FILE is for future Bundle and PyPi download stats script
+  - LIB_CHECK_FILE='bin/adabot/library_report_'`date +%Y%m%d`'.txt' LIB_DL_STATS_FILE='bin/adabot/library_stats_'`date +%Y%m%d`'.txt'
+
+# Will need AWS S3 credentials added to the Travis settings
+#addons:
+#  artifacts:
+#    paths:
+#      - $(ls bin/adabot/* | tr "\n" ":")
+#    target_paths: /adabot
+
+script:
+  # A folder for Adabot files
+  - mkdir -p bin/adabot
+
+  # Run the Bundle update script
+  - echo "(Placeholder) Updating Bundle..." && echo -en 'travis_fold:start:update\\r'
+  - echo "Running Bundle Update..."
+  #- python -m adabot.circuitpython_bundle
+  - echo -en 'travis_fold:end:update\\r'
+
+  # Run the circuitpython_libraries.py report; output a file with results for AWS
+  - echo "Running library checks..." && echo -en 'travis_fold:start:lib_check\\r'
+  - python -m adabot.circuitpython_libraries -o $LIB_CHECK_FILE
+  - echo -en 'travis_fold:end:lib_check\\r'
+
+  # (Future) Run the circuitpython_library_[download_stats].py; output a file with results for AWS
+  - echo -e "Getting Library Download Stats..." && echo -en 'travis_fold:start:stats\\r'
+  - echo -en 'travis_fold:start:stats\\r'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,23 +10,23 @@ cache:
 env:
     # LIB_CHECK_FILE is for circuitpython_libraries.py output
     # LIB_DL_STATS_FILE is for future Bundle and PyPi download stats script
-  - LIB_CHECK_FILE='bin/adabot/library_report_'`date +%Y%m%d`'.txt' LIB_DL_STATS_FILE='bin/adabot/library_stats_'`date +%Y%m%d`'.txt'
+  - LIB_CHECK_FILE='bin/adabot/library_report_'`date +%Y%m%d`'.txt' LIB_DL_STATS_FILE='bin/adabot/library_download_stats_'`date +%Y%m%d`'.txt'
 
 # Will need AWS S3 credentials added to the Travis settings
-#addons:
-#  artifacts:
-#    paths:
-#      - $(ls bin/adabot/* | tr "\n" ":")
-#    target_paths: /adabot
+addons:
+  artifacts:
+  paths:
+    - $(ls bin/adabot/* | tr "\n" ":")
+  target_paths: /adabot
+  debug: true
 
 script:
   # A folder for Adabot files
   - mkdir -p bin/adabot
 
   # Run the Bundle update script
-  - echo "(Placeholder) Updating Bundle..." && echo -en 'travis_fold:start:update\\r'
-  - echo "Running Bundle Update..."
-  #- python -m adabot.circuitpython_bundle
+  - echo "Updating Bundle..." && echo -en 'travis_fold:start:update\\r'
+  - python -m adabot.circuitpython_bundle
   - echo -en 'travis_fold:end:update\\r'
 
   # Run the circuitpython_libraries.py report; output a file with results for AWS
@@ -34,6 +34,7 @@ script:
   - python -m adabot.circuitpython_libraries -o $LIB_CHECK_FILE
   - echo -en 'travis_fold:end:lib_check\\r'
 
-  # (Future) Run the circuitpython_library_[download_stats].py; output a file with results for AWS
-  - echo -e "Getting Library Download Stats..." && echo -en 'travis_fold:start:stats\\r'
-  - echo -en 'travis_fold:start:stats\\r'
+  # Run the circuitpython_library_download_stats.py; output a file with results for AWS
+  - echo "Getting Library Download Stats..." && echo -en 'travis_fold:start:stats\\r'
+  - python -m adabot.circuitpython_download_stats -o $LIB_DL_STAT_FILE
+  - echo -en 'travis_fold:end:stats\\r'


### PR DESCRIPTION
Fixes #16.

## Adabot is ready to fly on her own! 🤖 🚀 

**This _will_ require some external setup.**

### Travis Settings
- Set the following environment variables:
    - ADABOT_GITHUB_ACCESS_TOKEN
    - ADABOT_TRAVIS_ACCESS_TOKEN
    - ARTIFACTS_KEY=(AWS access key id)
    - ARTIFACTS_SECRET=(AWS secret access key)
    - ARTIFACTS_BUCKET=(S3 bucket name)
    - ARTIFACTS_REGION (if it isn't the default "us-east-1")
- Turn off:
    - Build pushed branches
    - Build pushed pull requests
- Add a cron job to run `daily`

### AWS S3 Bucket
I've never worked with any AWS buckets, so these are guesses:

- Create `/adabot` directory, if needed. Travis will push the artifacts there (currently)
- Allow Adabot's Travis write access

## RFC 
@tannewt please give this a good look. I've used both the bundle's and core's `.travis.yml`s to work through this. However, it was also done with a lot of documentation reading.

I ran the `circuitpython_libraries` script on Travis with both pushed code and crons. Didn't run the `circuipython_bundle` for obvious reasons, and `circuitpython_libraries_download_stats` wasn't merged yet. Also, didn't push artifacts to AWS, but did have Travis deploy to releases successfully (since deleted). 

Travis builds can be viewed here: https://travis-ci.com/sommersoft/adabot/builds/90934238.