### PR TITLE
Fix 'list_repos()'

### DIFF
--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -262,7 +262,7 @@ def list_repos():
         links = result.headers["Link"]
         #repos.extend(result.json()["items"]) # uncomment and comment below, to include all forks
         repos.extend(repo for repo in result.json()["items"] if (repo["owner"]["login"] == "adafruit" and
-                     repo["name"].startswith("Adafruit_CircuitPython")))
+                     (repo["name"].startswith("Adafruit_CircuitPython") or repo["name"] == "circuitpython")))
 
         next_url = None
         for link in links.split(","):

--- a/adabot/circuitpython_library_download_stats.py
+++ b/adabot/circuitpython_library_download_stats.py
@@ -105,7 +105,7 @@ def run_stat_check():
     output_handler("Adafruit CircuitPython Library PyPi downloads for the past week: ")
     repos = cpy_libs.list_repos()
     for repo in repos:
-        if repo["owner"] == "adafruit" and repo["name"].startswith("Adafruit_CircuitPython"):
+        if (repo["owner"]["login"] == "adafruit" and repo["name"].startswith("Adafruit_CircuitPython")):
             if cpy_libs.repo_is_on_pypi(repo):
                 pypi_downloads[repo["name"]] = get_pypi_stats(repo["name"])
     for stat in sorted(pypi_downloads.items()):

--- a/adabot/circuitpython_library_download_stats.py
+++ b/adabot/circuitpython_library_download_stats.py
@@ -105,8 +105,9 @@ def run_stat_check():
     output_handler("Adafruit CircuitPython Library PyPi downloads for the past week: ")
     repos = cpy_libs.list_repos()
     for repo in repos:
-        if cpy_libs.repo_is_on_pypi(repo):
-            pypi_downloads[repo["name"]] = get_pypi_stats(repo["name"])
+        if repo["owner"] == "adafruit" and repo["name"].startswith("Adafruit_CircuitPython"):
+            if cpy_libs.repo_is_on_pypi(repo):
+                pypi_downloads[repo["name"]] = get_pypi_stats(repo["name"])
     for stat in sorted(pypi_downloads.items()):
         output_handler(" * {0}: {1}".format(stat[0], stat[1]))
 


### PR DESCRIPTION
When I updated `list_repos()` a while back to only return Adafruit owned `Adafruit_CircuitPython` repos, it seemed to drop `circuitpython` core repo which was causing this:
```
State of CircuitPython + Libraries
Overall
* 23 pull requests merged
  * 7 authors - dhalbert, kattni, tannewt, caternuson, process1183, ladyada, brennen
  * 5 reviewers - dhalbert, tannewt, kattni, caternuson, brennen
* 10 closed issues by 4 people, 5 opened by 4 people

Core
* 0 pull requests merged
  * 0 authors -
  * 0 reviewers -
* 0 open pull requests
* 0 closed issues by 0 people, 0 opened by 0 people
* 58 open issues
  * https://github.com/adafruit/circuitpython/issues
```
This PR fixes that...