### PR TITLE
More Appropriate requests Timeouts

### DIFF
--- a/adabot/circuitpython_library_download_stats.py
+++ b/adabot/circuitpython_library_download_stats.py
@@ -47,7 +47,7 @@ file_data = []
 
 def get_pypi_stats(repo):
     api_url = "https://pypistats.org/api/packages/" + repo.replace("_", "-").lower() + "/recent"
-    pypi_stats = requests.get(api_url, timeout=10)
+    pypi_stats = requests.get(api_url, timeout=30)
     if not pypi_stats.ok:
         return "Failed to retrieve data ({})".format(pypi_stats.text)
 

--- a/adabot/github_requests.py
+++ b/adabot/github_requests.py
@@ -52,6 +52,8 @@ def _fix_kwargs(kwargs):
             kwargs["params"]["access_token"] = access_token
         else:
             kwargs["params"] = {"access_token": access_token}
+    if "timeout" not in kwargs:
+        kwargs["timeout"] = 30
     return kwargs
 
 def get(url, **kwargs):

--- a/adabot/pypi_requests.py
+++ b/adabot/pypi_requests.py
@@ -38,6 +38,8 @@ def _fix_url(url):
     return url
 
 def _fix_kwargs(kwargs):
+    if "timeout" not in kwargs:
+        kwargs["timeout"] = 30
     return kwargs
 
 def get(url, **kwargs):

--- a/adabot/travis_requests.py
+++ b/adabot/travis_requests.py
@@ -56,6 +56,8 @@ def _fix_kwargs(kwargs):
             "User-Agent": user_agent,
             "Travis-API-Version": "3"
         }
+    if "timeout" not in kwargs:
+        kwargs["timeout"] = 30
     return kwargs
 
 def get(url, **kwargs):


### PR DESCRIPTION
This moves `timeout=n` for `requests.get()` to the appropriate "getters": `github_requests.py`, `pypi_requests.py`, and `travis_requests.py`. For any calls in other scripts that directly call `requests.get()`, the timeout is set inline.


Also updated all timeouts to 30 seconds. This would be "serious internet trouble" levels.