### PR TITLE
Validators - A La Carte

### DIFF
--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -1074,13 +1074,14 @@ if __name__ == "__main__":
         validators = []
         for func in cmd_line_args.validator.split(","):
             try:
-                validators.append(eval(func))
-            except NameError:
-                output_handler("Error: '{}' is not an available validator.\n" \
-                               "Available validators are: {}".format(func.strip(),
+                if not func.startswith("validate"):
+                    raise KeyError
+                validators.append(sys.modules[__name__].__dict__[func.strip()])
+            except KeyError:
+                output_handler("Error: '{0}' is not an available validator.\n" \
+                               "Available validators are: {1}".format(func.strip(),
                                "validate_contents, validate_repo_state, validate_travis, validate_readthedocs, validate_core_driver_page, validate_in_pypi, validate_release_state"))
                 sys.exit()
-
     try:
         run_library_checks()
     except:

--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -1080,7 +1080,7 @@ if __name__ == "__main__":
             except KeyError:
                 output_handler("Error: '{0}' is not an available validator.\n" \
                                "Available validators are: {1}".format(func.strip(),
-                               "validate_contents, validate_repo_state, validate_travis, validate_readthedocs, validate_core_driver_page, validate_in_pypi, validate_release_state"))
+                               ", ".join([vals for vals in sys.modules[__name__].__dict__ if vals.startswith("validate")])))
                 sys.exit()
     try:
         run_library_checks()

--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -37,12 +37,14 @@ cmd_line_parser = argparse.ArgumentParser(description="Adabot utility for Circui
                                           prog="Adabot CircuitPython Libraries Utility")
 cmd_line_parser.add_argument("-o", "--output_file", help="Output log to the filename provided.",
                              metavar="<OUTPUT FILENAME>", dest="output_file")
-cmd_line_parser.add_argument("-v", "--verbose", help="Set the level of verbosity printed to the command prompt."
+cmd_line_parser.add_argument("-p", "--print", help="Set the level of verbosity printed to the command prompt."
                              " Zero is off; One is on (default).", type=int, default=1, dest="verbose", choices=[0,1])
 cmd_line_parser.add_argument("-e", "--error_depth", help="Set the threshold for outputting an error list. Default is 5.",
                              dest="error_depth", type=int, default=5, metavar="n")
 cmd_line_parser.add_argument("-t", "--token", help="Prompt for a GitHub token to use for activating Travis.",
                              dest="gh_token", action="store_true")
+cmd_line_parser.add_argument("-v", "--validator", help="Run only the validator(s) supplied in a string.", dest="validator",
+                             metavar='"validator1, validator2, ..."')
 
 # Define constants for error strings to make checking against them more robust:
 ERROR_ENABLE_TRAVIS = "Unable to enable Travis build"
@@ -1068,6 +1070,18 @@ if __name__ == "__main__":
     github_token = cmd_line_args.gh_token
     if cmd_line_args.output_file:
         output_filename = cmd_line_args.output_file
+    if cmd_line_args.validator:
+        validators = []
+        for func in cmd_line_args.validator.split(","):
+            try:
+                validators.append(eval(func))
+            except NameError:
+                print("Error: '{}' is not an available validator.\n" \
+                      "Available validators are: {}".format(func.strip(),
+                      "validate_contents, validate_repo_state, validate_travis, validate_readthedocs, validate_core_driver_page, validate_in_pypi, validate_release_state"))
+                sys.exit()
+
+    print(validators)
 
     try:
         run_library_checks()

--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -1076,12 +1076,10 @@ if __name__ == "__main__":
             try:
                 validators.append(eval(func))
             except NameError:
-                print("Error: '{}' is not an available validator.\n" \
-                      "Available validators are: {}".format(func.strip(),
-                      "validate_contents, validate_repo_state, validate_travis, validate_readthedocs, validate_core_driver_page, validate_in_pypi, validate_release_state"))
+                output_handler("Error: '{}' is not an available validator.\n" \
+                               "Available validators are: {}".format(func.strip(),
+                               "validate_contents, validate_repo_state, validate_travis, validate_readthedocs, validate_core_driver_page, validate_in_pypi, validate_release_state"))
                 sys.exit()
-
-    print(validators)
 
     try:
         run_library_checks()


### PR DESCRIPTION
Fixes #24 

The core insights still run every time; I can remove that if desired.

Example:
```
(.env) sommersoft@thespacebetween:~/Dev/adabot/adabot$ python3 -m adabot.circuitpython_libraries -v "validate_release_state"
Latest pylint is: 2.2.0
Found 120 repos to check.
Found 114 submodules in the bundle.
Running GitHub checks as sommersoft
Running Travis checks as sommersoft
4300 requests remaining this hour
4200 requests remaining this hour
4100 requests remaining this hour
4000 requests remaining this hour
3900 requests remaining this hour
3800 requests remaining this hour

State of CircuitPython + Libraries
Overall
* 13 pull requests merged
  * 9 authors - C47D, tannewt, jerryneedell, dhalbert, pdp7, sommersoft, kattni, caternuson, adammhaile
  * 5 reviewers - ladyada, brennen, dhalbert, tannewt, kattni
* 14 closed issues by 7 people, 8 opened by 8 people

Core
* 5 pull requests merged
  * 4 authors - sommersoft, C47D, dhalbert, tannewt
  * 4 reviewers - ladyada, kattni, dhalbert, tannewt
* 8 open pull requests
  * https://github.com/adafruit/circuitpython/pull/1351
  * https://github.com/adafruit/circuitpython/pull/1347
  * https://github.com/adafruit/circuitpython/pull/1344
  * https://github.com/adafruit/circuitpython/pull/1329
  * https://github.com/adafruit/circuitpython/pull/1323
  * https://github.com/adafruit/circuitpython/pull/1294
  * https://github.com/adafruit/circuitpython/pull/1274
  * https://github.com/adafruit/circuitpython/pull/1144
* 8 closed issues by 3 people, 4 opened by 4 people
* 61 open issues
  * https://github.com/adafruit/circuitpython/issues

Download stats 
  <REMOVED FOR BREVITY>

Libraries
* 8 pull requests merged
  * 5 authors - jerryneedell, pdp7, kattni, caternuson, adammhaile
  * 5 reviewers - ladyada, brennen, dhalbert, tannewt, kattni
* 13 open pull requests
   <REMOVED FOR BREVITY>
* 6 closed issues by 4 people, 4 opened by 4 people
* 61 open issues
   <REMOVED FOR BREVITY>
5 out of 119 repos need work.


Library repository has no releases. - 4
  * https://github.com/adafruit/Adafruit_CircuitPython_CPython
  * https://github.com/adafruit/Adafruit_CircuitPython_AT86RF233
  * https://github.com/adafruit/Adafruit_CircuitPython_SK9822
  * https://github.com/adafruit/Adafruit_CircuitPython_US100

Library has new commits since last release. - 1
```