### PR TITLE
Fix Bundle Update On Travis

### DIFF
--- a/adabot/circuitpython_bundle.py
+++ b/adabot/circuitpython_bundle.py
@@ -39,7 +39,11 @@ bundles = ["Adafruit_CircuitPython_Bundle", "CircuitPython_Community_Bundle"]
 def fetch_bundle(bundle, bundle_path):
     if not os.path.isdir(bundle_path):
         os.makedirs(bundle_path, exist_ok=True)
-        git.clone("-o", "adafruit", "https://github.com/adafruit/" + bundle + ".git", bundle_path)
+        if "TRAVIS" in os.environ:
+            git_url = "https://" + os.environ["ADABOT_GITHUB_ACCESS_TOKEN"] + "@github.com/adafruit/"
+            git.clone("-o", "adafruit", git_url + bundle + ".git", bundle_path)
+        else:
+            git.clone("-o", "adafruit", "https://github.com/adafruit/" + bundle + ".git", bundle_path)
     working_directory = os.getcwd()
     os.chdir(bundle_path)
     git.pull()
@@ -353,6 +357,9 @@ def new_release(bundle, bundle_path):
 
 if __name__ == "__main__":
     directory = os.path.abspath(".bundles")
+    if "TRAVIS" in os.environ:
+        git.config("--global", "user.name", "adabot")
+        git.config("--global", "user.email", os.environ["ADABOT_EMAIL"])
     for bundle in bundles:
         bundle_path = os.path.join(directory, bundle)
         try:


### PR DESCRIPTION
@tannewt I looked into using the GitHub API, but it seems like more work than its worth to update the submodules and get all of the info through the API. Seems it will have to traverse each submodule and grab the release tag, then update the submodule `HEAD` file. Not sure how that would affect the release message. I'm also not sure it will avoid having to explicitly use the access token on `PUSH`es. 

I can keep looking into it and actually put some code down, but figure we can at least have this running in the mean time.

This will need Adabot's email added to the Travis Environment Variables, with the name as `ADABOT_EMAIL`. If desired, I can hardcode it in like the `git config user.name = adabot` is. 