### PR TITLE
Fix Syntax Error And Remove Travis Container (sudo: false)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 # TravisCI config for running Adabot on autopilot.
 dist: trusty
-sudo: false
 language: python
 python:
   - "3.6"

--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -525,8 +525,8 @@ def validate_contents(repo):
         if ".readthedocs.yml" in files:
             fn = ".readthedocs.yml"
         file_info = content_list[files.index(fn)]
-        if file_info["sha"] != "f4243ad548bc5e4431f2d3c5d486f6c9c863888b" and
-           file_info["sha"] != "78a4671650248f4382e6eb72dab71c2d86824ca2":
+        if (file_info["sha"] != "f4243ad548bc5e4431f2d3c5d486f6c9c863888b" and
+           file_info["sha"] != "78a4671650248f4382e6eb72dab71c2d86824ca2"):
             errors.append(ERROR_MISMATCHED_READTHEDOCS)
     else:
         errors.append(ERROR_MISSING_READTHEDOCS)


### PR DESCRIPTION
Fixes the syntax error I introduced with #38. Boneheaded me didn't enclose the conditional with parens. I ran it locally after this fix; runs fine.

Also removed `sudo: false` from .travis.yml, since Travis is now ignoring it and having everything run in a VM.