### PR TITLE
Add Arduino Release "Status" & Add Arduino Checks To Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,12 @@ cache:
   pip: true
 
 env:
-    # LIB_CHECK_FILE is for circuitpython_libraries.py output
+    # LIB_CHECK_CP_FILE is for circuitpython_libraries.py output
+    # LIB_CHECK_ARD_FILE is for arduino_libraries.py output
     # LIB_DL_STATS_FILE is for future Bundle and PyPi download stats script
-  - LIB_CHECK_FILE='bin/adabot/library_report_'`date +%Y%m%d`'.txt' LIB_DL_STATS_FILE='bin/adabot/library_download_stats_'`date +%Y%m%d`'.txt'
+  - LIB_CHECK_CP_FILE='bin/adabot/circuitpython_library_report_'`date +%Y%m%d`'.txt'
+  - LIB_CHECK_ARD_FILE='bin/adabot/arduino_library_report_'`date +%Y%m%d`'.txt'
+  - LIB_DL_STATS_FILE='bin/adabot/library_download_stats_'`date +%Y%m%d`'.txt'
 
 addons:
   artifacts:
@@ -23,16 +26,21 @@ script:
   - mkdir -p bin/adabot
 
   # Run the Bundle update script
-  - echo "Updating Bundle..." && echo -en 'travis_fold:start:update\\r'
+  - echo "Updating CircuitPython Library Bundles..." && echo -en 'travis_fold:start:update\\r'
   - python -m adabot.circuitpython_bundle
   - echo -en 'travis_fold:end:update\\r'
 
   # Run the circuitpython_libraries.py report; output a file with results for AWS
-  - echo "Running library checks..." && echo -en 'travis_fold:start:lib_check\\r'
-  - python -m adabot.circuitpython_libraries -o $LIB_CHECK_FILE
+  - echo "Running CircuitPython library checks..." && echo -en 'travis_fold:start:lib_check\\r'
+  - python -m adabot.circuitpython_libraries -o $LIB_CHECK_CP_FILE
   - echo -en 'travis_fold:end:lib_check\\r'
 
   # Run the circuitpython_library_download_stats.py; output a file with results for AWS
-  - echo "Getting Library Download Stats..." && echo -en 'travis_fold:start:stats\\r'
+  - echo "Getting CircuitPython Library Download Stats..." && echo -en 'travis_fold:start:stats\\r'
   - python -m adabot.circuitpython_library_download_stats -o $LIB_DL_STATS_FILE
   - echo -en 'travis_fold:end:stats\\r'
+
+  # Run the arduino_libraries.py report; output a file with results for AWS
+  - echo "Running Arduino library checks..." && echo -en 'travis_fold:start:ard_lib_check\\r'
+  - python -m adabot.arduino_libraries -o $LIB_CHECK_ARD_FILE
+  - echo -en 'travis_fold:end:ard_lib_check\\r'


### PR DESCRIPTION
Fixes step 2 in #33, by checking if/how many commits have been made to an Arduino library since its last release.

Also adds the Arduino library script to run on Travis and deploy to the AWS bucket.

Release "status" is output like so:
```
Libraries have commits since last release: (83)
  Repo                                     Latest Release   Commits Behind   
  ----                                     --------------   --------------   
  HL1606-LED-Strip-PWM                     1.0.0            2                
  Adafruit-HX8340B                         1.0.0            2                
  Adafruit-Flora-Pixel-Library             1.0.0            2                
  Adafruit_TLC5947                         1.0.2            2                
  Adafruit_SoftServo                       1.0.0            2                
  Adafruit_TinyFlash                       1.0.0            2                
  CC3000_MDNS                              1.0.0            2                
```