### PR TITLE
Fix What I Broke & Forgot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,10 @@ env:
     # LIB_CHECK_CP_FILE is for circuitpython_libraries.py output
     # LIB_CHECK_ARD_FILE is for arduino_libraries.py output
     # LIB_DL_STATS_FILE is for future Bundle and PyPi download stats script
-  - LIB_CHECK_CP_FILE='bin/adabot/circuitpython_library_report_'`date +%Y%m%d`'.txt'
-  - LIB_CHECK_ARD_FILE='bin/adabot/arduino_library_report_'`date +%Y%m%d`'.txt'
-  - LIB_DL_STATS_FILE='bin/adabot/library_download_stats_'`date +%Y%m%d`'.txt'
+  - |
+    LIB_CHECK_CP_FILE='bin/adabot/circuitpython_library_report_'`date +%Y%m%d`'.txt' \
+    LIB_CHECK_ARD_FILE='bin/adabot/arduino_library_report_'`date +%Y%m%d`'.txt' \
+    LIB_DL_STATS_FILE='bin/adabot/library_download_stats_'`date +%Y%m%d`'.txt' \
 
 addons:
   artifacts:

--- a/adabot/arduino_libraries.py
+++ b/adabot/arduino_libraries.py
@@ -37,6 +37,7 @@ cmd_line_parser.add_argument("-v", "--verbose", help="Set the level of verbosity
                              " Zero is off; One is on (default).", type=int, default=1, dest="verbose", choices=[0,1])
 output_filename = None
 verbosity = 1
+file_data = []
 
 def list_repos():
     """ Return a list of all Adafruit repositories with 'Arduino' in either the
@@ -216,3 +217,8 @@ if __name__ == "__main__":
             output_handler(exc_val, quiet=True)
 
         raise
+    finally:
+        if output_filename is not None:
+            with open(output_filename, 'w') as f:
+                for line in file_data:
+                    f.write(str(line) + "\n")


### PR DESCRIPTION
Fixes the environment variable change I made to help readability, which caused 3 instances of the script to run. There may still be some `git push` tweaking needed in the bundle update, but I can't tell if the triple run caused the errors or not. The nice thing is, looking at the last Travis log, even if the git URL is printed the log obscures the access token.

Fixes `arduino_libraries` outputting results to a file, which I forgot to finish & test.


Summary: 🤦‍♂️ 