### PR TITLE
Hopefully Handle Redis Error On Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ python:
 cache:
   pip: true
 
+services:
+  - redis-server
+
 env:
     # LIB_CHECK_CP_FILE is for circuitpython_libraries.py output
     # LIB_CHECK_ARD_FILE is for arduino_libraries.py output


### PR DESCRIPTION
Now that we're past the `git push` error for the bundle updates, we're getting [`redis` errors](https://travis-ci.org/adafruit/adabot/jobs/465254706):
```
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/redis/client.py", line 667, in execute_command
    connection.send_command(*args)
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/redis/connection.py", line 610, in send_command
    self.send_packed_command(self.pack_command(*args))
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/redis/connection.py", line 585, in send_packed_command
    self.connect()
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/redis/connection.py", line 489, in connect
    raise ConnectionError(self._error_message(e))
redis.exceptions.ConnectionError: Error 111 connecting to localhost:6379. Connection refused.
```

After some googling, seems we need to turn on `redis-server` in Travis.

_Note: I tried to replicate the `circuitpython_libraries` error, but couldn't. Seems it may have just been a hiccup with GH API when the cron ran._