### PR TITLE
Fix Unecessary Failure

### DIFF
--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -981,7 +981,7 @@ def print_circuitpython_download_stats():
     found_unstable = False
     found_stable = False
     for release in releases:
-        published = datetime.datetime.strptime(release["published_at"], "%Y-%m-%dT%H:%M:%SZ")
+        #published = datetime.datetime.strptime(release["published_at"], "%Y-%m-%dT%H:%M:%SZ")
         if not found_unstable and not release["draft"] and release["prerelease"]:
             found_unstable = True
         elif not found_stable and not release["draft"] and not release["prerelease"]:

--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -981,7 +981,6 @@ def print_circuitpython_download_stats():
     found_unstable = False
     found_stable = False
     for release in releases:
-        #published = datetime.datetime.strptime(release["published_at"], "%Y-%m-%dT%H:%M:%SZ")
         if not found_unstable and not release["draft"] and release["prerelease"]:
             found_unstable = True
         elif not found_stable and not release["draft"] and not release["prerelease"]:


### PR DESCRIPTION
The download stats function in `circuitpython_libraries.py` was assigning the published date for releases to a variable. A few days ago, the Travis cron job started failing on the assignment, because the pub date was returning `None`.

I tried to verify this by running the API call for releases in a web browser, which didn't provide any insight.

I then inserted some debug prints in the script, and realized that the API response was including the draft release for `4.0.0-alpha.4`. The draft release wasn't returned in the web browser; weird.

At any rate, the variable with the published date isn't used anywhere, so the simplest fix: don't assign it. 😄 
