### PR TITLE
Travis Migration Update

### DIFF
--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -643,7 +643,7 @@ def validate_travis(repo):
 
             new_access_token = {"scopes": ["public_repo"],
                                 "note": "TravisCI release token for " + repo["full_name"],
-                                "note_url": "https://travis-ci.org/" + repo["full_name"]}
+                                "note_url": "https://travis-ci.com/" + repo["full_name"]}
             token = github.post("/authorizations", json=new_access_token, auth=full_auth)
             if not token.ok:
                 print(token.text)

--- a/adabot/travis_requests.py
+++ b/adabot/travis_requests.py
@@ -35,7 +35,7 @@ import requests
 
 def _fix_url(url):
     if url.startswith("/"):
-        url = "https://api.travis-ci.org" + url
+        url = "https://api.travis-ci.com" + url
     return url
 
 def _auth_token():

--- a/template-env.sh
+++ b/template-env.sh
@@ -7,4 +7,6 @@ export ADABOT_GITHUB_ACCESS_TOKEN=<your personal access token>
 # Note you want the 'Travis Token' (third option) and NOT the 'Access Token'.  Use the ruby gem mentioned to generate.
 # KEEP THIS TOKEN SECRET AND SAFE! Although it is unclear what access the token grants (Travis seems to imply it's less
 # risk to share), always assume secrets like these are dangerous to expose to others.
+# Note 2: since all CircuitPython repositories have been migragted to travis-ci.com, be sure to use an access token
+# from '.com', not '.org'. These tokens are not interchangeable.
 export ADABOT_TRAVIS_ACCESS_TOKEN=<your Travis token>


### PR DESCRIPTION
This updates Travis requests to use `.com` vs `.org`.

**This requires token updates!**
`.com` and `.org` tokens are **not** interchangeable. `ADABOT_TRAVIS_ACCESS_TOKEN` will need to be updated in your personal usage (env.sh), as well as the Adabot-on-Travis environment variable.

I added a non-interchangeable token note to `template_env.sh`.