### PR TITLE
Improve Visibility of Repos Needing Release

### DIFF
--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -1001,7 +1001,7 @@ def run_library_checks():
 
     list_repos_for_errors = [ERROR_NOT_IN_BUNDLE]
     output_handler()
-    for error in repos_by_error:
+    for error in sorted(repos_by_error):
         if not repos_by_error[error]:
             continue
         output_handler()


### PR DESCRIPTION
Fixes #49.

Categorizes the `validate_release_state()` results into time deltas: new commits over a month old, within the last month, and within the last week. Also appends the number of days since the oldest commit to the repo link.

```
(.env) sommersoft@thespacebetween:~/Dev/adabot/adabot$ python3 -m adabot.circuitpython_libraries -v "validate_release_state" -e 200
blah
blah
blah

Library has new commits since last release within the last month. - 101
  * https://github.com/adafruit/Adafruit_CircuitPython_BoardTest (26 days)
  * https://github.com/adafruit/Adafruit_CircuitPython_PCA9685 (19 days)
  * https://github.com/adafruit/Adafruit_CircuitPython_DS2413 (19 days)
  * https://github.com/adafruit/Adafruit_CircuitPython_FocalTouch (19 days)
  * https://github.com/adafruit/Adafruit_CircuitPython_MPL3115A2 (19 days)
  * https://github.com/adafruit/Adafruit_CircuitPython_MCP9808 (19 days)
  * https://github.com/adafruit/Adafruit_CircuitPython_MCP4725 (19 days)
  * https://github.com/adafruit/Adafruit_CircuitPython_MAX31865 (19 days)
  * https://github.com/adafruit/Adafruit_CircuitPython_SI5351 (19 days)
  * https://github.com/adafruit/Adafruit_CircuitPython_SI7021 (19 days)
  * https://github.com/adafruit/Adafruit_CircuitPython_STMPE610 (19 days)

Library has new commits since last release over a month ago. - 10
  * https://github.com/adafruit/Adafruit_CircuitPython_BME680 (44 days)
  * https://github.com/adafruit/Adafruit_CircuitPython_Register (37 days)
  * https://github.com/adafruit/Adafruit_CircuitPython_AM2320 (37 days)
  * https://github.com/adafruit/Adafruit_CircuitPython_seesaw (37 days)
  * https://github.com/adafruit/Adafruit_CircuitPython_HCSR04 (37 days)
  * https://github.com/adafruit/Adafruit_CircuitPython_BNO055 (37 days)
  * https://github.com/adafruit/Adafruit_CircuitPython_APDS9960 (37 days)
  * https://github.com/adafruit/Adafruit_CircuitPython_IRRemote (45 days)
  * https://github.com/adafruit/Adafruit_CircuitPython_TSL2561 (38 days)
  * https://github.com/adafruit/Adafruit_CircuitPython_TLC5947 (39 days)

Library has new commits since last release within the last week. - 1
  * https://github.com/adafruit/Adafruit_CircuitPython_Debouncer (4 days)
```

It's a bit of a kludge to get the `days` data into the results, but it works. Turns out we can get a list of commits from the compare API too; I was just building the URL backwards. I almost limited the commit dates to commits that had `Merge` in the message, but that would override any patches since they commit straight to the repo.

In this iteration, I cannot further sort in each category (e.g. descending by oldest). Would require a larger refactor in how the results are compiled and output.