### PR TITLE
Small Updates To DL Stats

### DIFF
--- a/adabot/circuitpython_library_download_stats.py
+++ b/adabot/circuitpython_library_download_stats.py
@@ -142,13 +142,13 @@ def run_stat_check():
 
     pypi_downloads = {}
     pypi_failures = []
-    downloads_list = [["| Repo", "| Last Week", "| Total |"],
-                      ["| ----", "|:--------:", "|:-----:|"]]
-    output_handler("Adafruit CircuitPython Library PyPi downloads: ")
+    downloads_list = [["| Library", "| Last Week", "| Total |"],
+                      ["|:-------", "|:--------:", "|:-----:|"]]
+    output_handler("Adafruit CircuitPython Library PyPi downloads:")
     output_handler()
     pypi_downloads, pypi_failures = get_pypi_stats()
     for stat in sorted(pypi_downloads.items(), key=operator.itemgetter(1,1), reverse=True):
-        downloads_list.append(["| " + str(stat[0]), " | " + str(stat[1][0]), " | " + str(stat[1][1]) +" |"])
+        downloads_list.append(["| " + str(stat[0]), "| " + str(stat[1][0]), "| " + str(stat[1][1]) +" |"])
 
     long_col = [(max([len(str(row[i])) for row in downloads_list]) + 3)
                 for i in range(len(downloads_list[0]))]


### PR DESCRIPTION
Couple tweaks to the PyPi stats:
- Renamed the `Repo` header to `Library`. Since this list is now used in the newsletter, seems a better description.

- Forced `align: left` in the Markdown table for the (now) `Library` column. When rendered in the newsletter, I think the `<center>` tag that wraps all of the content was forcing it to align center, which makes it a little difficult to read.