### PR TITLE
Fix 'ERROR_RTD_VALID_VERSIONS_FAILED'

### DIFF
--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -720,7 +720,6 @@ def validate_readthedocs(repo):
             errors.append(ERROR_GITHUB_RELEASE_FAILED)
         else:
             if latest_release.json()["tag_name"] not in [tag["verbose_name"] for tag in valid_versions["versions"]]:
-                #print("{} tag: {} | {} | {}".format(repo["name"], latest_release.json()["tag_name"], subproject["id"], [tag["verbose_name"] for tag in valid_versions["versions"]]))
                 errors.append(ERROR_RTD_MISSING_LATEST_RELEASE)
 
     # There is no API which gives access to a list of builds for a project so we parse the html

--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -709,7 +709,7 @@ def validate_readthedocs(repo):
         errors.append(ERROR_RTD_ADABOT_MISSING)
 
     valid_versions = requests.get(
-        "https://readthedocs.org/api/v2/project/{}/valid_versions/".format(subproject["id"]),
+        "https://readthedocs.org/api/v2/project/{}/active_versions/".format(subproject["id"]),
         timeout=15)
     if not valid_versions.ok:
         errors.append(ERROR_RTD_VALID_VERSIONS_FAILED)
@@ -719,7 +719,8 @@ def validate_readthedocs(repo):
         if not latest_release.ok:
             errors.append(ERROR_GITHUB_RELEASE_FAILED)
         else:
-            if latest_release.json()["tag_name"] not in valid_versions["flat"]:
+            if latest_release.json()["tag_name"] not in [tag["verbose_name"] for tag in valid_versions["versions"]]:
+                #print("{} tag: {} | {} | {}".format(repo["name"], latest_release.json()["tag_name"], subproject["id"], [tag["verbose_name"] for tag in valid_versions["versions"]]))
                 errors.append(ERROR_RTD_MISSING_LATEST_RELEASE)
 
     # There is no API which gives access to a list of builds for a project so we parse the html


### PR DESCRIPTION
Fixes #63.

I was tempted to remove `ERROR_RTD_MISSING_LATEST_RELEASE` (the "Ignore me!" one), but decided not to. Also, couldn't find any way to make it be reliable info.