### PR TITLE
Fix Dropped Repos

### DIFF
--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -275,7 +275,7 @@ def list_repos():
     """
     repos = []
     result = github.get("/search/repositories",
-                        params={"q":"Adafruit_CircuitPython in:name fork:true",
+                        params={"q":"Adafruit_CircuitPython user:adafruit",
                                 "per_page": 100,
                                 "sort": "updated",
                                 "order": "asc"}
@@ -847,11 +847,12 @@ def gather_insights(repo, insights, since):
     list_repos function) and will fill in the provided insights dictionary
     with analytics it computes for the repository.
     """
+
     if repo["owner"]["login"] != "adafruit":
         return
     params = {"sort": "updated",
               "state": "all",
-              "since": str(since)}
+              "since": since.strftime("%Y-%m-%dT%H:%M:%SZ")}
     response = github.get("/repos/" + repo["full_name"] + "/issues", params=params)
     if not response.ok:
         output_handler("Insights request failed: {}".format(repo["full_name"]))


### PR DESCRIPTION
This started out as a debugging operation to address the library insights always returning zeroes. 

After a couple days of trying to debug that, I finally realized that `list_repos()` was only returning 120-125 repos. The repos that weren't showing up, were coincidently the ones that were updated recently.

So, I dropped the `in:name` and `fork:true` from the search string, and added `user:adafruit`. This resulted in 149 repos being returned, which seems **much** closer to the actual number of library repos.

And, it caused this:
```
Libraries
* 15 pull requests merged
  * 8 authors - makermelissa, brentru, martymcguire, kattni, demophoon, jerryneedell, willingc, ladyada
  * 5 reviewers - makermelissa, kattni, brentru, siddacious, ladyada
```

I also changed the `since` date formatting for the API call to grab issues. This was prior to finding the above, but I think having it better formatted is a good idea (it contained spaces before).

🌴 