### PR TITLE
Prune Issue Info From Report

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ idna==2.6
 redis==2.10.6
 requests==2.20.0
 sh==1.12.14
-urllib3>=1.24
+urllib3==1.24


### PR DESCRIPTION
All of the Library open issues and infrastructure errors are now on circuitpython.org. So, the `circuitpython_libraries.py` report now only points to that location. Example of new runs: https://gist.github.com/sommersoft/8d41ff618d52d42a1993a7133e651c81

- Open PRs, and contributor/reviewer information is still gathered and listed.

- Infrastructure validators can still be run using the `-v` command line arg. Added the ability to use `-v all` to run all validators, and retained `-v "validator_1, validator_2, ..."`.

- Did a smidge of PEP8 cleanup. Which makes the diff really hard to read...sorry.

- Removed some old debug `print`s, and also fixed an exception handler that I had commented out previously.