### PR TITLE
Fix Example Checks

### DIFF
--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -397,6 +397,7 @@ if __name__ == "__main__":
         startup_message.append(" - Report output will be saved to: {}".format(output_filename))
 
     validators = []
+    validator_names = []
     if cmd_line_args.validator:
         if cmd_line_args.validator != "all":
             validators = []
@@ -423,7 +424,7 @@ if __name__ == "__main__":
 
         startup_message.append(" - These validators will run: {}".format(", ".join(validator_names)))
 
-        if "validate_contents" not in validators:
+        if "validate_contents" not in validator_names:
             validator_kwarg_list["validate_contents_quiet"] = True
             validators.insert(0, [val[1] for val in default_validators if "validate_contents" in val[0]][0])
 

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -478,7 +478,7 @@ class library_validator():
             if len(examples_list) < 1:
                 errors.append(ERROR_MISSING_EXAMPLE_FILES)
             else:
-                lib_name = repo["name"][repo["name"].rfind("_") + 1:].lower()
+                lib_name = repo["name"][repo["name"].rfind("CircuitPython_") + 14:].lower()
                 all_have_name = True
                 simpletest_exists = False
                 for example in examples_list:


### PR DESCRIPTION
During `validate_contents`, the check to make sure each example is prefixed with the library name, the repo's name was used. The `rfind()` was set to look for the first `_`, which resulted in errors when the repo had an extra underscore beyond `CircuitPython`. Example: `Adafruit_CircuitPython_Thermal_Printer` gave a lookup string of `printer`.

This changes the the `rfind()` to look for `CircuitPython_` instead, ensuring that the whole library name is captured.

Also fixed a couple latent bugs from the refactor, wrt to the `-v` command line flag.