### PR TITLE
missing travis + has ino + has library.properties + github delay hotfix

### DIFF
--- a/adabot/arduino_libraries.py
+++ b/adabot/arduino_libraries.py
@@ -192,7 +192,7 @@ def run_arduino_lib_checks():
     output_handler("Running Arduino Library Checks")
     output_handler("Getting list of libraries to check...")
 
-    repo_list = list_repos()[0:10]
+    repo_list = list_repos()
     output_handler("Found {} Arduino libraries to check\n".format(len(repo_list)))
     failed_lib_prop = [["  Repo", "Release Tag", "library.properties Version"], ["  ----", "-----------", "--------------------------"]]
     needs_release_list = [["  Repo", "Latest Release", "Commits Behind"], ["  ----", "--------------", "--------------"]]

--- a/adabot/arduino_libraries.py
+++ b/adabot/arduino_libraries.py
@@ -180,7 +180,7 @@ def validate_travis(repo):
         return True
 
 def validate_example(repo):
-    """Validate if a repo has any *.ino files.
+    """Validate if a repo has any files in examples directory
     """
     repo_has_ino = github.get("/repos/adafruit/" + repo["name"] + "/contents/examples")
     if repo_has_ino.ok and len(repo_has_ino.json()):

--- a/adabot/arduino_libraries.py
+++ b/adabot/arduino_libraries.py
@@ -80,14 +80,14 @@ def is_arduino_library(repo):
     else:
         return False
 
-def print_list_output(title="", list=[]):
+def print_list_output(title, coll):
     ""
     output_handler()
-    output_handler(title.format(len(list)))
-    long_col = [(max([len(str(row[i])) for row in list]) + 3)
-                for i in range(len(list[0]))]
+    output_handler(title.format(len(coll)))
+    long_col = [(max([len(str(row[i])) for row in coll]) + 3)
+                for i in range(len(coll[0]))]
     row_format = "".join(["{:<" + str(this_col) + "}" for this_col in long_col])
-    for lib in list:
+    for lib in coll:
         output_handler(row_format.format(*lib))
 
 def output_handler(message="", quiet=False):

--- a/adabot/arduino_libraries.py
+++ b/adabot/arduino_libraries.py
@@ -175,8 +175,8 @@ def validate_release_state(repo):
 def validate_travis(repo):
     """Validate if a repo has .travis.yml.
     """
-    repo_has_ino = github.get("/repos/" + repo["full_name"] + "/contents/.travis.yml")
-    if not repo_last_release.ok:
+    repo_has_travis = github.get("/repos/" + repo["full_name"] + "/contents/.travis.yml")
+    if not repo_has_travis.ok:
         return True
 
 def has_ino(repo):

--- a/adabot/arduino_libraries.py
+++ b/adabot/arduino_libraries.py
@@ -211,16 +211,17 @@ def run_arduino_lib_checks():
                 failed_lib_prop.append(["  " + str(repo["name"]), lib_check[0], lib_check[1]])
 
         needs_release = validate_release_state(repo)
-        missing_travis = validate_travis(repo) and has_ino(repo)
-        missing_library_properties = has_ino(repo) and not has_library_properties(repo)
+        missing_travis = validate_travis(repo) 
+        have_ino = has_ino(repo)
+        missing_library_properties = not has_library_properties(repo)
 
         if needs_release:
             needs_release_list.append(["  " + str(repo["name"]), needs_release[0], needs_release[1]])
 
-        if missing_travis:
+        if missing_travis and have_ino:
             missing_travis_list.append(["  " + str(repo["name"])])
 
-        if missing_library_properties:
+        if missing_library_properties and have_ino:
             missing_library_properties_list.append(["  " + str(repo["name"])])
 
     if len(failed_lib_prop) > 2:

--- a/adabot/arduino_libraries.py
+++ b/adabot/arduino_libraries.py
@@ -176,7 +176,7 @@ def validate_travis(repo):
     """Validate if a repo has .travis.yml.
     """
     repo_has_travis = github.get("/repos/" + repo["full_name"] + "/contents/.travis.yml")
-    if not repo_has_travis.ok:
+    if repo_has_travis.ok:
         return True
 
 def has_ino(repo):
@@ -211,7 +211,7 @@ def run_arduino_lib_checks():
                 failed_lib_prop.append(["  " + str(repo["name"]), lib_check[0], lib_check[1]])
 
         needs_release = validate_release_state(repo)
-        missing_travis = validate_travis(repo) 
+        missing_travis = not validate_travis(repo) 
         have_ino = has_ino(repo)
         missing_library_properties = not has_library_properties(repo)
 

--- a/adabot/github_requests.py
+++ b/adabot/github_requests.py
@@ -71,8 +71,9 @@ def get(url, **kwargs):
                     time.sleep(300)
                 else:
                     reset_diff = rate_limit_reset - datetime.datetime.now()
+
                     print("Sleeping {} seconds".format(reset_diff.seconds))
-                    time.sleep(reset_diff.seconds)
+                    time.sleep(reset_diff.seconds + 1)
         if remaining % 100 == 0:
             print(remaining, "requests remaining this hour")
     return response


### PR DESCRIPTION
added:
* missing travis validator (checks if repo has .travis.yml)
* has *.ino validator (checks if repo has any ino files)
* has *.library.properties (checks if repo has library.properties) file

also as limits for github API `search` was lower found that the code runs too early when rate limit is reached and fixed the calculations problem (there was one sec difference that trigger while loop infinitely).

there is also some todos:

- make possible to run every check separately from cli
- displaying / logging limits is now a little bit messy, should be fixed
