### PR TITLE
Add "Days Open" Metrics; Validate Issue Labels; CirPy.org AWS Transition; Misc Maintenance

### DIFF
--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -99,6 +99,7 @@ default_validators = [
     if vals[0].startswith("validate")
 ]
 
+pr_sort_re = re.compile("(?<=\(Open\s)(.+)(?=\sdays)")
 
 def run_library_checks(validators, bundle_submodules, latest_pylint, kw_args):
     """runs the various library checking functions"""
@@ -204,7 +205,10 @@ def run_library_checks(validators, bundle_submodules, latest_pylint, kw_args):
     output_handler("Core")
     print_pr_overview(core_insights)
     output_handler("* {} open pull requests".format(len(core_insights["open_prs"])))
-    for pr in core_insights["open_prs"]:
+    sorted_prs = sorted(core_insights["open_prs"],
+                        key=lambda days: int(pr_sort_re.search(days).group(1)),
+                        reverse=True)
+    for pr in sorted_prs:
         output_handler("  * {}".format(pr))
     print_issue_overview(core_insights)
     output_handler("* {} open issues".format(len(core_insights["open_issues"])))
@@ -223,7 +227,10 @@ def run_library_checks(validators, bundle_submodules, latest_pylint, kw_args):
     output_handler("Libraries")
     print_pr_overview(lib_insights)
     output_handler("* {} open pull requests".format(len(lib_insights["open_prs"])))
-    for pr in lib_insights["open_prs"]:
+    sorted_prs = sorted(lib_insights["open_prs"],
+                        key=lambda days: int(pr_sort_re.search(days).group(1)),
+                        reverse=True)
+    for pr in sorted_prs:
         output_handler("  * {}".format(pr))
     print_issue_overview(lib_insights)
     output_handler("* {} open issues".format(len(lib_insights["open_issues"])))

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -830,10 +830,17 @@ class library_validator():
 
         for issue in issues:
             created = datetime.datetime.strptime(issue["created_at"], "%Y-%m-%dT%H:%M:%SZ")
+            days_open = datetime.datetime.today() - created
+            if days_open.days < 0: # opened earlier today
+                days_open += datetime.timedelta(days=(days_open.days * -1))
             if "pull_request" in issue:
-                insights["open_prs"].append(issue["pull_request"]["html_url"])
+                pr_link = "{0} (Open {1} days)".format(issue["pull_request"]["html_url"],
+                                                       days_open.days)
+                insights["open_prs"].append(pr_link)
             else:
-                insights["open_issues"].append(issue["html_url"])
+                issue_link = "{0} (Open {1} days)".format(issue["html_url"],
+                                                          days_open.days)
+                insights["open_issues"].append(issue_link)
 
         # get milestones for core repo
         if repo["name"] == "circuitpython":

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -447,7 +447,7 @@ class library_validator():
                 return [ERROR_UNABLE_PULL_REPO_CONTENTS]
 
         content_list = content_list.json()
-        files = ""
+        files = []
         # an empty repo will return a 'message'
         if "message" not in content_list:
             files = [x["name"] for x in content_list]

--- a/adabot/lib/common_funcs.py
+++ b/adabot/lib/common_funcs.py
@@ -234,6 +234,8 @@ def is_new_or_updated(repo):
     new_releases = 0
     releases = result.json()
     for release in releases:
+        if not release["published_at"]:
+            continue
         release_date = datetime.datetime.strptime(
             release["published_at"],
             "%Y-%m-%dT%H:%M:%SZ"

--- a/adabot/update_cp_org_libraries.py
+++ b/adabot/update_cp_org_libraries.py
@@ -190,25 +190,6 @@ if __name__ == "__main__":
     print("Running circuitpython.org/libraries updater...")
 
     run_time = datetime.datetime.now()
-    # Travis CI weekly cron jobs do not allow or guarantee that they will be run
-    # on a specific day of the week. So, we set the cron to run daily, and then
-    # check for the day we want this to run.
-    if "TRAVIS" in os.environ:
-        should_run = int(os.environ["CP_ORG_UPDATER_RUN_DAY"])
-        if run_time.isoweekday() != should_run:
-            delta_days = should_run - run_time.isoweekday()
-            run_delta = datetime.timedelta(days=delta_days)
-            should_run_date = run_time + run_delta
-            msg = [
-                "Aborting...",
-                " - Today is not {}.".format(should_run_date.strftime("%A")),
-                " - Next scheduled run is: {}".format(should_run_date.strftime("%Y-%m-%d")),
-                " - To run the updater on a different day, change the",
-                "   'CP_ORG_UPDATER_RUN_DAY' environment variable in Travis.",
-                " - Day is a number between 1 & 7, with 1 being Monday."
-            ]
-            print("\n".join(msg))
-            sys.exit()
 
     working_directory = os.path.abspath(os.getcwd())
     #cp_org_dir = os.path.join(working_directory, ".cp_org")
@@ -329,11 +310,8 @@ if __name__ == "__main__":
     }
     json_obj = json.dumps(build_json, indent=2)
 
-    if "TRAVIS" in os.environ:
-        update_json_file(json_obj)
-    else:
-        #update_json_file(json_obj)
-        if local_file_output:
-            with open(output_filename, "w") as json_file:
-                json.dump(build_json, json_file, indent=2)
-        print(json_obj)
+    #update_json_file(json_obj)
+    if local_file_output:
+        with open(output_filename, "w") as json_file:
+            json.dump(build_json, json_file, indent=2)
+    print(json_obj)


### PR DESCRIPTION
This PR got a little out of hand, as multiple things got rolled into it.

Add "Days Open" Metrics
------------------------------
- Calculates the number of days that an issue or PR has been open.
- Applies to `circuitpython_libraries` and `update_cp_org_libraries`.
- Appends the number of days open to the issue/PR on reports

Validate Issue Lables
------------------------
- Adds a new validator to check the available issue labels on each library.
- Standard labels are: `bug, documentation, enhancement, good first issue`

circuitpython.org/libraries Transition to AWS
--------------------------------------------------
- Removes the check that ensured `update_cp_org_libraries` was only run once a week, on a certain day. New system will run daily.
- Removes the function & call that created a PR to the circuipython-org repo with updates to `libraries.json`. New system will rely on using the `-o` command line argument to output a file (will be accomplished in circuitpython-org's `travis.yml`).

Miscellaneous Maintenance
-------------------------------
- In `common_funcs.is_new_or_updated()`, a draft/unpublished release would cause an exception. This is now handled by ensuring that `published_at` contains valid data.
- Handle empty repos in `circuitpython_library_validators.validate_contents()` in a way that allows them to be added to both the `BUNDLE_IGNORE_LIST` so subsequent validators aren't run, and is also returned as an in-work-repo.