### PR TITLE
Schedule Hacktoberfest Labeling

### DIFF
--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -35,6 +35,7 @@ from adabot import travis_requests as travis
 from adabot import pypi_requests as pypi
 from adabot.lib import circuitpython_library_validators as cirpy_lib_vals
 from adabot.lib import common_funcs
+from adabot.lib import assign_hacktober_label as hacktober
 
 # Setup ArgumentParser
 cmd_line_parser = argparse.ArgumentParser(
@@ -132,6 +133,8 @@ def run_library_checks(validators, bundle_submodules, latest_pylint, kw_args):
         "open_issues": [],
         "issue_authors": set(),
         "issue_closers": set(),
+        "hacktober_assigned": 0,
+        "hacktober_removed": 0,
     }
     core_insights = copy.deepcopy(lib_insights)
     for k in core_insights:
@@ -425,6 +428,20 @@ def print_issue_overview(*insights):
     output_handler("* {} closed issues by {} people, {} opened by {} people"
                    .format(closed_issues, len(issue_closers),
                    new_issues, len(issue_authors)))
+
+    # print Hacktoberfest labels changes if its Hacktober
+    in_season, season_action = hacktober.is_hacktober_season()
+    if in_season:
+        hacktober_changes = ""
+        if season_action == "add":
+            hacktober_changes = "* Assigned Hacktoberfest label to {} issues.".format(
+                sum([x["hacktober_assigned"] for x in insights])
+            )
+        elif season_action == "remove":
+            hacktober_changes += "* Removed Hacktoberfest label from {} issues.".format(
+                sum([x["hacktober_removed"] for x in insights])
+            )
+        output_handler(hacktober_changes)
 
 if __name__ == "__main__":
     validator_kwarg_list = {}

--- a/adabot/lib/assign_hacktober_label.py
+++ b/adabot/lib/assign_hacktober_label.py
@@ -20,42 +20,21 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+import argparse
 import requests
 
 from adabot import github_requests as github
 from adabot.lib import common_funcs
 
+cli_args = argparse.ArgumentParser(description="Hacktoberfest Label Assigner")
+cli_args.add_argument("-r", "--remove-label", action="store_true",
+                     help="Option to remove Hacktoberfest labels, instead of adding them.",
+                     dest="remove_label")
 
-def ensure_hacktober_label_exists(repo):
-    """ Checks if the 'Hacktoberfest' label exists on the repo.
-        If not, creates the label.
+
+def get_open_issues(repo):
+    """ Retrieve all open issues for given repo.
     """
-    response = github.get("/repos/" + repo["full_name"] + "/labels")
-    if not response.ok:
-        print("Failed to retrieve labels for '{}'".format(repo["name"]))
-        return False
-
-    repo_labels = [label["name"] for label in response.json()]
-
-    hacktober_exists = {"Hacktoberfest", "hacktoberfest"} & set(repo_labels)
-    if not hacktober_exists:
-        params = {
-            "name": "Hacktoberfest",
-            "color": "f2b36f",
-            "description": "DigitalOcean's Hacktoberfest"
-        }
-        result = github.post("/repos/" + repo["full_name"] + "/labels", json=params)
-        if not result.status_code == 201:
-            print("Failed to create new Hacktoberfest label for: {}".format(repo["name"]))
-            return False
-
-    return True
-
-def assign_hacktoberfest(repo):
-    """ Gathers open issues on a repo, and assigns the 'Hacktoberfest' label
-        to each issue if its not already assigned.
-    """
-    labels_assigned = 0
 
     params = {
         "state": "open",
@@ -86,48 +65,100 @@ def assign_hacktoberfest(repo):
 
         response = requests.get(link, timeout=30)
 
+    return issues
+
+
+def ensure_hacktober_label_exists(repo):
+    """ Checks if the 'Hacktoberfest' label exists on the repo.
+        If not, creates the label.
+    """
+    response = github.get("/repos/" + repo["full_name"] + "/labels")
+    if not response.ok:
+        print("Failed to retrieve labels for '{}'".format(repo["name"]))
+        return False
+
+    repo_labels = [label["name"] for label in response.json()]
+
+    hacktober_exists = {"Hacktoberfest", "hacktoberfest"} & set(repo_labels)
+    if not hacktober_exists:
+        params = {
+            "name": "Hacktoberfest",
+            "color": "f2b36f",
+            "description": "DigitalOcean's Hacktoberfest"
+        }
+        result = github.post("/repos/" + repo["full_name"] + "/labels", json=params)
+        if not result.status_code == 201:
+            print("Failed to create new Hacktoberfest label for: {}".format(repo["name"]))
+            return False
+
+    return True
+
+def assign_hacktoberfest(repo, issues=None, remove_labels=False):
+    """ Gathers open issues on a repo, and assigns the 'Hacktoberfest' label
+        to each issue if its not already assigned.
+    """
+    labels_assigned = 0
+
+    if not issues:
+        issues = get_open_issues(repo)
+
     for issue in issues:
         label_names = [label["name"] for label in issue["labels"]]
         has_good_first = "good first issue" in label_names
         has_hacktober = {"Hacktoberfest", "hacktoberfest"} & set(label_names)
 
-        if has_good_first and not has_hacktober:
-            label_exists = ensure_hacktober_label_exists(repo)
-            if not label_exists:
-                continue
+        if remove_labels:
+            if has_hacktober:
+                label_names = [
+                    label for label in lable_names
+                    if label not in has_hacktober
+                ]
+        else:
+            if has_good_first and not has_hacktober:
+                label_exists = ensure_hacktober_label_exists(repo)
+                if not label_exists:
+                    continue
 
-            label_names.append("Hacktoberfest")
-            params = {
-                "labels": label_names
-            }
-            result = github.patch("/repos/"
-                                  + repo["full_name"]
-                                  + "/issues/"
-                                  + str(issue["number"]),
-                                  json=params)
+        params = {
+            "labels": label_names
+        }
+        result = github.patch("/repos/"
+                              + repo["full_name"]
+                              + "/issues/"
+                              + str(issue["number"]),
+                              json=params)
 
-            if result.ok:
-                labels_assigned += 1
-            else:
-                # sadly, GitHub will only silently ignore labels that are
-                # not added and return a 200. so this will most likely only
-                # trigger on endpoint/connection failures.
-                print("Failed to add Hacktoberfest label to: {}".format(issue["url"]))
+        if result.ok:
+            labels_changed += 1
+        else:
+            # sadly, GitHub will only silently ignore labels that are
+            # not added and return a 200. so this will most likely only
+            # trigger on endpoint/connection failures.
+            print("Failed to add Hacktoberfest label to: {}".format(issue["url"]))
 
-    return labels_assigned
+    return labels_changed
 
-def process_hacktoberfest(repo):
-    result = assign_hacktoberfest(repo)
+def process_hacktoberfest(repo, remove_labels=False):
+    result = assign_hacktoberfest(repo, remove_labels)
     return result
 
 
 if __name__ == "__main__":
     labels_assigned = 0
+    args = cli_args.parse_args()
 
-    print("Checking for open issues to assign the Hacktoberfest label to...")
+    remove_labels = args.remove_label
+
+    if not remove_labels:
+        print("Checking for open issues to assign the Hacktoberfest label to...")
+    else:
+        print("Checking for open issues to remove the Hacktoberfest label from...")
 
     repos = common_funcs.list_repos()
     for repo in repos:
-        labels_assigned += process_hacktoberfest(repo)
+        labels_assigned += process_hacktoberfest(repo, remove_labels)
 
-    print("Added the Hacktoberfest label to {} issues.".format(labels_assigned))
+    if not remove_labels:
+        print("Added the Hacktoberfest label to {} issues.".format(labels_assigned))
+    else:
+        print("Removed the Hacktoberfest label from {} issues.".format(labels_assigned))

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -28,6 +28,7 @@ from adabot import github_requests as github
 from adabot import travis_requests as travis
 from adabot import pypi_requests as pypi
 from adabot.lib import common_funcs
+from adabot.lib import assign_hacktober_label as hacktober
 
 
 # Define constants for error strings to make checking against them more robust:
@@ -858,6 +859,24 @@ class library_validator():
                 issue_link = "{0} (Open {1} days)".format(issue["html_url"],
                                                           days_open.days)
                 insights["open_issues"].append(issue_link)
+
+        # process Hacktoberfest labels if it is Hacktoberfest season
+        in_season, season_action = hacktober.is_hacktober_season()
+        if in_season:
+            hacktober_issues = [
+                issue for issue in issues if "pull_request" not in issue
+            ]
+            if season_action == "add":
+                insights["hacktober_assigned"] += (
+                    hacktober.assign_hacktoberfest(repo,
+                                                   issues=hacktober_issues)
+                )
+            elif season_action == "remove":
+                insights["hacktober_removed"] += (
+                    hacktober.assign_hacktoberfest(repo,
+                                                   issues=hacktober_issues,
+                                                   remove_labels=True)
+                )
 
         # get milestones for core repo
         if repo["name"] == "circuitpython":


### PR DESCRIPTION
This adds Hacktoberfest labeling to `circuitpython_libraries` so it is run daily:

- 29 September thru 30 October: Hacktoberfest label is added to any open issue with `good first issue` label.
- 1 November thru 10 November: Hacktoberfest label is removed from any open issue that has it.
- The rest of the year: isn't run or reported...