### PR TITLE
Fix Redis Connection Error For Bundle Cron

### DIFF
--- a/.github/workflows/bundle_cron.yml
+++ b/.github/workflows/bundle_cron.yml
@@ -50,5 +50,6 @@ jobs:
       env:
         ADABOT_EMAIL: ${{ secrets.ADABOT_EMAIL }}
         ADABOT_GITHUB_ACCESS_TOKEN: ${{ secrets.ADABOT_GITHUB_ACCESS_TOKEN }}
+        REDIS_PORT: ${{ job.services.redis.port[6379] }}
       run: |
         python3 -u -m adabot.circuitpython_bundle

--- a/adabot/circuitpython_bundle.py
+++ b/adabot/circuitpython_bundle.py
@@ -31,8 +31,13 @@ from datetime import date
 import sh
 from sh.contrib import git
 
-import redis
-redis = redis.StrictRedis()
+import redis as redis_py
+
+redis = None
+if "GITHUB_WORKSPACE" in os.environ:
+    redis = redis_py.StrictRedis(port=os.environ["REDIS_PORT"])
+else:
+    redis = redis_py.StrictRedis()
 
 bundles = ["Adafruit_CircuitPython_Bundle", "CircuitPython_Community_Bundle"]
 


### PR DESCRIPTION
This fixes the Redis connection error, by passing the correct (forwarded) port from the Docker redis image.

Successful test can be seen [here](https://github.com/sommersoft/adabot/runs/348142271).