### PR TITLE
Another Fix for bundle_cron.yml

### DIFF
--- a/.github/workflows/bundle_cron.yml
+++ b/.github/workflows/bundle_cron.yml
@@ -50,6 +50,6 @@ jobs:
       env:
         ADABOT_EMAIL: ${{ secrets.ADABOT_EMAIL }}
         ADABOT_GITHUB_ACCESS_TOKEN: ${{ secrets.ADABOT_GITHUB_ACCESS_TOKEN }}
-        REDIS_PORT: ${{ job.services.redis.port[6379] }}
+        REDIS_PORT: ${{ job.services.redis.ports[6379] }}
       run: |
         python3 -u -m adabot.circuitpython_bundle


### PR DESCRIPTION
This fixes, again, the Redis instance in `bundle_cron.yml`. Failed transcription on previous PR...