### PR TITLE
Daily Report: Handle Core Download Stats Request Failure

### DIFF
--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -282,7 +282,10 @@ def print_circuitpython_download_stats():
     """Gather and report analytics on the main CircuitPython repository."""
     response = github.get("/repos/adafruit/circuitpython/releases")
     if not response.ok:
-        output_handler("Core CircuitPython GitHub analytics request failed.")
+        output_handler(
+            "Core CircuitPython GitHub download statistics request failed."
+        )
+        return
     releases = response.json()
 
     found_unstable = False


### PR DESCRIPTION
This is to better handle the failure we're currently having with the API request to get download statistics for the CircuitPython core. I ran a local test, and it gets past the error just fine.

An example of the current failure can be seen at this link: https://api.github.com/repos/adafruit/circuitpython/releases

```
{
  "message": "Server Error"
}
```
And the header info:
```
Request URL: https://api.github.com/repos/adafruit/circuitpython/releases
Request Method: GET
Status Code: 502 Bad Gateway
Remote Address: 192.30.255.117:443
Referrer Policy: no-referrer-when-downgrade
```

I don't have a good handle on why the API request is failing, as it passes on a lot of the other repos I've tried by hand. To include my own fork of the core repo. 🤷‍♂ 