### PR TITLE
Switch To New GitHub API Authentication Scheme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,7 +115,7 @@ Applying Patches To All CircuitPython Libraries
 ================================================
 To apply a patch to all CircuitPython libraries (only guaranteed for files shared
 among all libraries, such as those included in the cookiecutter (e.g. README.rst,
-.travis.yml, etc), do the following:
+ etc), do the following:
 
 1. Apply your update(s) to any library as normal, using ``git commit``. It is recommended to
 give a short, detailed description of the patch. This description will be used by the next

--- a/adabot/github_requests.py
+++ b/adabot/github_requests.py
@@ -35,6 +35,8 @@ import sys
 import time
 import traceback
 
+from base64 import b64encode
+
 TIMEOUT = 60
 
 def _fix_url(url):
@@ -52,11 +54,15 @@ def _fix_kwargs(kwargs):
     else:
         kwargs["headers"] = {"Accept": "application/vnd.github.hellcat-preview+json"}
     if "ADABOT_GITHUB_ACCESS_TOKEN" in os.environ and "auth" not in kwargs:
+        user = os.environ.get("ADABOT_GITHUB_USER", "")
         access_token = os.environ["ADABOT_GITHUB_ACCESS_TOKEN"]
+        basic_encoded = b64encode(str(user + ":" + access_token).encode()).decode()
+        auth_header = "Basic {}".format(basic_encoded)
+        
         if "params" in kwargs:
-            kwargs["params"]["access_token"] = access_token
+            kwargs["headers"]["Authorization"] = auth_header
         else:
-            kwargs["params"] = {"access_token": access_token}
+            kwargs["headers"] = {"Authorization": auth_header}
 
     return kwargs
 

--- a/adabot/github_requests.py
+++ b/adabot/github_requests.py
@@ -58,11 +58,8 @@ def _fix_kwargs(kwargs):
         access_token = os.environ["ADABOT_GITHUB_ACCESS_TOKEN"]
         basic_encoded = b64encode(str(user + ":" + access_token).encode()).decode()
         auth_header = "Basic {}".format(basic_encoded)
-        
-        if "params" in kwargs:
-            kwargs["headers"]["Authorization"] = auth_header
-        else:
-            kwargs["headers"] = {"Authorization": auth_header}
+
+        kwargs["headers"]["Authorization"] = auth_header
 
     return kwargs
 

--- a/template-env.sh
+++ b/template-env.sh
@@ -2,11 +2,6 @@
 #  https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
 # KEEP THIS TOKEN SECRET AND SAFE! Anyone with access to the token has FULL CONTROL of your GitHub account!
 export ADABOT_GITHUB_ACCESS_TOKEN=<your personal access token>
-# Go here to generate a travis access token:
-#  https://blog.travis-ci.com/2013-01-28-token-token-token
-# Note you want the 'Travis Token' (third option) and NOT the 'Access Token'.  Use the ruby gem mentioned to generate.
-# KEEP THIS TOKEN SECRET AND SAFE! Although it is unclear what access the token grants (Travis seems to imply it's less
-# risk to share), always assume secrets like these are dangerous to expose to others.
-# Note 2: since all CircuitPython repositories have been migragted to travis-ci.com, be sure to use an access token
-# from '.com', not '.org'. These tokens are not interchangeable.
-export ADABOT_TRAVIS_ACCESS_TOKEN=<your Travis token>
+
+# This is the username associated with the access token.
+export ADABOT_GITHUB_USER=<username>


### PR DESCRIPTION
The use of `access_token` query parameters with the GitHub API [has been deprecated](https://developer.github.com/changes/#authenticating-using-query-parameters).

This change conforms to the use of the new scheme using HTTP Basic authentication.

I ran both `circuitpython_libraries.py` and `update_cp_org_libraries.py`, and both function as expected.

**Required updates:**
- `ADABOT_GITHUB_USER=<username>` which is attached to the access token must be available in the environment variables. Affects this repository and circuitpython-org.
- If you want to run it locally, you'll also need to add that envvar to your env (`env.sh`)

@tannewt, I left the exception handling that kept tokens from leaking to stdout. I'm _fairly_ certain they won't be needed now, since the token won't make it to the URI. Since you wrote it in though, I wanted to get your take on it.