### PR TITLE
Update Actions To Use New Environment Variable

### DIFF
--- a/.github/workflows/bundle_cron.yml
+++ b/.github/workflows/bundle_cron.yml
@@ -49,6 +49,7 @@ jobs:
     - name: Run adabot.circuitpython_bundle
       env:
         ADABOT_EMAIL: ${{ secrets.ADABOT_EMAIL }}
+        ADABOT_GITHUB_USER: ${{ secrets.ADABOT_GITHUB_USER }}
         ADABOT_GITHUB_ACCESS_TOKEN: ${{ secrets.ADABOT_GITHUB_ACCESS_TOKEN }}
         REDIS_PORT: ${{ job.services.redis.ports[6379] }}
       run: |

--- a/.github/workflows/reports_cron.yml
+++ b/.github/workflows/reports_cron.yml
@@ -23,6 +23,7 @@ jobs:
     # be limited (they run on all forks' default branches).
     if: startswith(github.repository, 'adafruit/')
     env:
+      ADABOT_GITHUB_USER: ${{ secrets.ADABOT_GITHUB_USER }}
       ADABOT_GITHUB_ACCESS_TOKEN: ${{ secrets.ADABOT_GITHUB_ACCESS_TOKEN }}
     steps:
       - name: Dump GitHub context


### PR DESCRIPTION
As mentioned in https://github.com/adafruit/adabot/pull/138#issuecomment-582993992, this updates the GitHub Actions workflows to make the `ADABOT_GITHUB_USER` environment variable available.

I used an assumptive `secrets.ADABOT_GITHUB_USER` source; let me know if it needs to be changed.