### PR TITLE
Add Community Bundle

### DIFF
--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -113,7 +113,8 @@ def run_library_checks(validators, bundle_submodules, latest_pylint, kw_args):
         latest_pylint = pylint_info.json()["info"]["version"]
     output_handler("Latest pylint is: {}".format(latest_pylint))
 
-    repos = common_funcs.list_repos(include_repos=('Adafruit_Blinka',))
+    repos = common_funcs.list_repos(include_repos=('Adafruit_Blinka',
+                                                   'CircuitPython_Community_Bundle'))
     output_handler("Found {} repos to check.".format(len(repos)))
     bundle_submodules = common_funcs.get_bundle_submodules()
     output_handler("Found {} submodules in the bundle.".format(len(bundle_submodules)))

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -186,9 +186,9 @@ class library_validator():
         errors = []
         if repo["has_wiki"]:
             errors.append(ERROR_WIKI_DISABLED)
-        if not repo["license"] and not repo["name"] in BUNDLE_IGNORE_LIST:
+        if not repo.get("license") and not repo["name"] in BUNDLE_IGNORE_LIST:
             errors.append(ERROR_MISSING_LICENSE)
-        if not repo["permissions"]["push"]:
+        if not repo.get("permissions", dict()).get("push"):
             errors.append(ERROR_MISSING_LIBRARIANS)
         if (not common_funcs.is_repo_in_bundle(full_repo["clone_url"], self.bundle_submodules)
             and not repo["name"] in BUNDLE_IGNORE_LIST):

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -188,7 +188,7 @@ class library_validator():
             errors.append(ERROR_WIKI_DISABLED)
         if not repo.get("license") and not repo["name"] in BUNDLE_IGNORE_LIST:
             errors.append(ERROR_MISSING_LICENSE)
-        if not repo.get("permissions", dict()).get("push"):
+        if not repo.get("permissions", {}).get("push"):
             errors.append(ERROR_MISSING_LIBRARIANS)
         if (not common_funcs.is_repo_in_bundle(full_repo["clone_url"], self.bundle_submodules)
             and not repo["name"] in BUNDLE_IGNORE_LIST):

--- a/adabot/update_cp_org_libraries.py
+++ b/adabot/update_cp_org_libraries.py
@@ -31,6 +31,8 @@ from adabot.lib import common_funcs
 from adabot.lib import circuitpython_library_validators as cpy_vals
 from adabot import github_requests as github
 
+DO_NOT_VALIDATE = ['CircuitPython_Community_Bundle']
+
 # Setup ArgumentParser
 cmd_line_parser = argparse.ArgumentParser(
     description="Adabot utility for updating circuitpython.org libraries info.",
@@ -146,7 +148,7 @@ if __name__ == "__main__":
 
     print("\n".join(startup_message))
 
-    repos = common_funcs.list_repos()
+    repos = common_funcs.list_repos(include_repos=("CircuitPython_Community_Bundle",))
 
     new_libs = {}
     updated_libs = {}
@@ -195,6 +197,9 @@ if __name__ == "__main__":
         if get_revs:
             reviewers.extend(get_revs)
         merged_pr_count_total += get_merge_count
+
+        if repo_name in DO_NOT_VALIDATE:
+            continue
 
         # run repo validators to check for infrastructure errors
         errors = validator.run_repo_validation(repo)


### PR DESCRIPTION
Fixes #134. 

- Adds Community Bundle issue and pull request stats to the daily report and the circuitpython.org/contributing scripts.
- For the circuitpython.org addition, the Community Bundle is not subjected to the infrastructure validators.
- Mitigated some `KeyError` exceptions I was getting in `validate_repo_state()`. The GitHub API results were missing the `license` and `permissions` keys. I couldn't find anything regarding changes to the API, and the circuitpython.org Actions job doesn't seem affected. Were there some access restrictions made?
