### PR TITLE
Update Pylint Validator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 certifi==2017.11.5
 chardet==3.0.4
 idna==2.6
+packaging==20.3
 redis==2.10.6
 requests==2.20.0
 sh==1.12.14


### PR DESCRIPTION
Remove use of eval.

Uses `packaging` library instead, to compare pylint versioning.

Addresses: https://github.com/adafruit/adabot/pull/149#pullrequestreview-373824327