### PR TITLE
Patch To Update Code of Conduct

### DIFF
--- a/adabot/lib/common_funcs.py
+++ b/adabot/lib/common_funcs.py
@@ -168,7 +168,7 @@ def list_repos(*, include_repos=None):
     """
     repos = []
     result = github.get("/search/repositories",
-                        params={"q":"Adafruit_CircuitPython user:adafruit archived:false",
+                        params={"q":"Adafruit_CircuitPython user:adafruit archived:false fork:true",
                                 "per_page": 100,
                                 "sort": "updated",
                                 "order": "asc"}

--- a/patches/0001-update-code-of-conduct-discord-moderation-contact-sec.patch
+++ b/patches/0001-update-code-of-conduct-discord-moderation-contact-sec.patch
@@ -1,0 +1,31 @@
+From 39d6a8d0c22d6b953974fca079bd794320fd22cc Mon Sep 17 00:00:00 2001
+From: sommersoft <sommersoft@gmail.com>
+Date: Sun, 15 Mar 2020 11:49:22 -0500
+Subject: [PATCH] update code of coduct: discord moderation contact section
+
+---
+ CODE_OF_CONDUCT.md | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/CODE_OF_CONDUCT.md b/CODE_OF_CONDUCT.md
+index d79c514..134d510 100644
+--- a/CODE_OF_CONDUCT.md
++++ b/CODE_OF_CONDUCT.md
+@@ -74,10 +74,10 @@ You may report in the following ways:
+ In any situation, you may send an email to <support@adafruit.com>.
+ 
+ On the Adafruit Discord, you may send an open message from any channel
+-to all Community Helpers by tagging @community helpers. You may also send an
+-open message from any channel, or a direct message to @kattni#1507,
+-@tannewt#4653, @Dan Halbert#1614, @cater#2442, @sommersoft#0222,
+-@Mr. Certainly#0472 or @Andon#8175.
++to all Community Moderators by tagging @community moderators. You may 
++also send an open message from any channel, or a direct message to 
++@kattni#1507, @tannewt#4653, @Dan Halbert#1614, @cater#2442, 
++@sommersoft#0222, @Mr. Certainly#0472 or @Andon#8175.
+ 
+ Email and direct message reports will be kept confidential.
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
- `common_funcs.py::list_repos()`: I had removed the `forks:true` from the search query quite some time ago. It turns out that Adafruit has a number of CircuitPython repos that are actually forks, which adabot has been missing due to the lack of searching for forks. This fixes that (but still only processes Adafruit repos).

- CoC Patch: After the "manual" update a couple days ago, there were some changes spotted. Luckily, now that they're all standard now (well, a few stragglers), we can git patch the changes.

Patch dry run:
```
$> python3 -m adabot.circuitpython_library_patches --local --dry-run 
   -p 0001-update-code-of-conduct-discord-moderation-contact-sec.patch
.... Beginning Patch Updates ....
.... Working directory: /home/sommersoft/Dev/adabot/adabot
.... Library directory: /home/sommersoft/Dev/adabot/adabot/.libraries/
.... Patches directory: /home/sommersoft/Dev/adabot/adabot/patches/
.... Deleting any previously cloned libraries
.... Running Patch Checks On 235 Repos ....
   . Skipping Adafruit_CircuitPython_L3GD20: patch does not apply
   . Skipping Adafruit_CircuitPython_HCSR04: patch does not apply
   . Skipping Adafruit_CircuitPython_DHT: patch does not apply
   . Skipping Adafruit_CircuitPython_LSM6DS: patch does not apply
   . Skipping Adafruit_CircuitPython_APDS9960: patch does not apply
   . Skipping Adafruit_CircuitPython_RockBlock: patch does not apply
   . Skipping Adafruit_CircuitPython_BLE_Adafruit: patch does not apply
   . Skipping Adafruit_CircuitPython_BLE_Radio: patch does not apply
*   . Skipping Adafruit_CircuitPython_Display_Button: patch does not apply
*   . Skipping Adafruit_CircuitPython_LED_Animation: patch does not apply
*   . Skipping Adafruit_CircuitPython_Logging: patch does not apply
*   . Skipping Adafruit_CircuitPython_Bitmap_Font: patch does not apply
*   . Skipping Adafruit_CircuitPython_Display_Shapes: patch does not apply
.... Patch Updates Completed ....
.... Patches Applied: 214
.... Patches Skipped: 13
.... Patches Failed: 8 
```
The skips marked with `*` are actually up-to-date. After running the patch, I'll run the "manual" update script on the remaining skips (they were either adafruit forks, or were missing from my forks).

The 8 failures are all due to the file not existing (WIP repos). 