### PR TITLE
Fix CircuitPythonLibrarians Permissions Validator

### DIFF
--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -226,7 +226,7 @@ class library_validator():
                 errors.append(ERROR_NOT_IN_BUNDLE)
 
         if (repo_fields.get("allow_squash_merge") or
-            repo_fields.get("allow_squash_merge")):
+            repo_fields.get("allow_rebase_merge")):
                 errors.append(ERROR_ONLY_ALLOW_MERGES)
         return errors
 

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -225,9 +225,6 @@ class library_validator():
                 # other repos.
                 errors.append(ERROR_NOT_IN_BUNDLE)
 
-        #if ("allow_squash_merge" not in repo_fields
-        #    or repo_fields["allow_squash_merge"]
-        #    or repo_fields["allow_rebase_merge"]):
         if (repo_fields.get("allow_squash_merge") or
             repo_fields.get("allow_squash_merge")):
                 errors.append(ERROR_ONLY_ALLOW_MERGES)

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -184,25 +184,52 @@ class library_validator():
         if not (repo["owner"]["login"] == "adafruit" and
                 repo["name"].startswith("Adafruit_CircuitPython")):
             return []
-        full_repo = github.get("/repos/" + repo["full_name"])
-        if not full_repo.ok:
-            return [ERROR_UNABLE_PULL_REPO_DETAILS]
-        full_repo = full_repo.json()
+
+        search_keys = {
+            "has_wiki",
+            "license",
+            "permissions",
+            "allow_squash_merge",
+            "allow_rebase_merge",
+        }
+
+        repo_fields = repo.copy()
+
+        repo_fields_keys = set(repo_fields.keys())
+        repo_missing_some_keys = search_keys.difference(repo_fields_keys)
+
+        if repo_missing_some_keys:
+            # only call the API if the passed in `repo` doesn't have what
+            # we need.
+            response = github.get("/repos/" + repo["full_name"])
+            if not response.ok:
+                return [ERROR_UNABLE_PULL_REPO_DETAILS]
+            repo_fields = response.json()
+
         errors = []
-        if repo["has_wiki"]:
+
+        if repo_fields.get("has_wiki"):
             errors.append(ERROR_WIKI_DISABLED)
-        if not repo.get("license") and not repo["name"] in BUNDLE_IGNORE_LIST:
-            errors.append(ERROR_MISSING_LICENSE)
-        if not repo.get("permissions", {}).get("push"):
+
+        if (not repo_fields.get("license") and
+            not repo["name"] in BUNDLE_IGNORE_LIST):
+                errors.append(ERROR_MISSING_LICENSE)
+
+        if not repo_fields.get("permissions", {}).get("push"):
             errors.append(ERROR_MISSING_LIBRARIANS)
-        if (not common_funcs.is_repo_in_bundle(full_repo["clone_url"], self.bundle_submodules)
-            and not repo["name"] in BUNDLE_IGNORE_LIST):
+
+        repo_in_bundle = common_funcs.is_repo_in_bundle(repo_fields["clone_url"],
+                                                        self.bundle_submodules)
+        if not repo_in_bundle and not repo["name"] in BUNDLE_IGNORE_LIST:
                 # Don't assume the bundle will bundle itself and possibly
                 # other repos.
                 errors.append(ERROR_NOT_IN_BUNDLE)
-        if ("allow_squash_merge" not in full_repo
-            or full_repo["allow_squash_merge"]
-            or full_repo["allow_rebase_merge"]):
+
+        #if ("allow_squash_merge" not in repo_fields
+        #    or repo_fields["allow_squash_merge"]
+        #    or repo_fields["allow_rebase_merge"]):
+        if (repo_fields.get("allow_squash_merge") or
+            repo_fields.get("allow_squash_merge")):
                 errors.append(ERROR_ONLY_ALLOW_MERGES)
         return errors
 


### PR DESCRIPTION
Fixes #146 

Originally I thought that they [re]moved the `permissions` field from the GitHub API response, but turns out that wasn't the issue. _My troubleshooting was with **un-authenticated** requests, which don't include the permissions field._

`validate_repo_state()` has been using the passed in `repo` variable which is generated via the Search API. It made its own call to the repos API, but none of the function used that response.

At some point though, the results passed in from the Search API (via `list_repos()`) started losing the `permissions` field. I'm not entirely sure if its a GitHub issue, or a `list_repos()` problem. But this works around it either way...

Result:
```
~/Dev/adabot/adabot:$> python3 -m adabot.circuitpython_libraries -v "validate_repo_state"
Running CircuitPython Library checks...
Report Date: 02 April 2020, 09:32PM
 - Depth for listing libraries with errors: 5
 - These validators will run: validate_repo_state

CircuitPythonLibrarians team missing or does not have write access - 2
  * https://github.com/adafruit/Adafruit_CircuitPython_NeoPixel
  * https://github.com/adafruit/Adafruit_CircuitPython_BLE_Contec_Pulse_Oximeter

Not in bundle. - 7
  * https://github.com/adafruit/Adafruit_CircuitPython_MCP4728
  * https://github.com/adafruit/Adafruit_CircuitPython_TestRepo
  * https://github.com/adafruit/Adafruit_CircuitPython_BLE_Adafruit
  * https://github.com/adafruit/Adafruit_CircuitPython_GFX
  * https://github.com/adafruit/Adafruit_CircuitPython_BLE_MIDI
  * https://github.com/adafruit/Adafruit_CircuitPython_APDS9500
  * https://github.com/adafruit/Adafruit_CircuitPython_CPython
```