### PR TITLE
Patch: Add Patchfile To Add Black Code Style Check To build.yml

### DIFF
--- a/patches/0001-build.yml-add-black-formatting-check.patch
+++ b/patches/0001-build.yml-add-black-formatting-check.patch
@@ -1,0 +1,24 @@
+From e725354300a8c8b9cdfcca9e8345568acee96d85 Mon Sep 17 00:00:00 2001
+From: sommersoft <sommersoft@gmail.com>
+Date: Tue, 7 Apr 2020 15:02:31 -0500
+Subject: [PATCH] build.yml: add black formatting check
+
+---
+ .github/workflows/build.yml | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/.github/workflows/build.yml b/.github/workflows/build.yml
+index 1dad804..b6977a9 100644
+--- a/.github/workflows/build.yml
++++ b/.github/workflows/build.yml
+@@ -44,4 +44,7 @@ jobs:
+     - name: Library version
+       run: git describe --dirty --always --tags
++    - name: Check formatting
++      run: |
++        black --check --target-version=py35 .
+     - name: PyLint
+       run: |
+-- 
+2.17.1
+


### PR DESCRIPTION
Patching dry-run:
```
~/Dev/adabot/adabot:$> python3 -m adabot.circuitpython_library_patches --local --dry-run 
                       -p 0001-build.yml-add-black-formatting-check.patch
.... Beginning Patch Updates ....
.... Working directory: /home/sommersoft/Dev/adabot/adabot
.... Library directory: /home/sommersoft/Dev/adabot/adabot/.libraries/
.... Patches directory: /home/sommersoft/Dev/adabot/adabot/patches/
.... Deleting any previously cloned libraries
.... Running Patch Checks On 239 Repos ....
   . Skipping Adafruit_CircuitPython_BLE_BroadcastNet: patch does not apply
   . Skipping Adafruit_CircuitPython_Bundle: patch does not apply
.... Patch Updates Completed ....
.... Patches Applied: 234
.... Patches Skipped: 2
.... Patches Failed: 3 

.... Patch Check Failure Report ....
>> Repo: Adafruit_CircuitPython_FONA    Patch: 0001-build.yml-add-black-formatting-check.patch
   Error: .github/workflows/build.yml: No such file or directory 
>> Repo: Adafruit_CircuitPython_BLE_Contec_Pulse_Oximeter       Patch: 0001-build.yml-add-black-formatting-check.patch
   Error: .github/workflows/build.yml: No such file or directory 
>> Repo: Adafruit_CircuitPython_BLE_Radio       Patch: 0001-build.yml-add-black-formatting-check.patch
   Error: .github/workflows/build.yml: No such file or directory 


.... Patch Apply Failure Report ....
No Failures
```
Skips are good. Failures aren't surprising. NeoPixel will fail when applying, due to repo permissions.