### PR TITLE
Allow Example Filename Underscore Variations Compared To Repo Name

### DIFF
--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -639,7 +639,7 @@ class library_validator():
                 def __check_lib_name(repo_name, file_name):
                     """ Nested function to test example file names.
                         Allows examples to either match the repo name,
-                        or have underscores separating the repo name.
+                        or have additional underscores separating the repo name.
                     """
                     file_names = set()
                     file_names.add(file_name)
@@ -654,41 +654,9 @@ class library_validator():
 
                     found = False
 
-""" Option 1:
-    Strips underscores from repo name and example name, and makes comparison
-
-                    repo_name_stripped = repo_name.replace("_", "")
-                    match = name_rebuilt.startswith(repo_name_stripped)
-                    print(
-                        f"Checking {repo_name} against {file_name}\n"
-                        f"\tRepo name stripped of '_': {repo_name_stripped}\n"
-                        f"\tRebuilt example name: {name_rebuilt}\n"
-                        f"\tMatch: {match}"
+                    return any(
+                        name.startswith(repo_name) for name in file_names
                     )
-                    return match
-"""
-
-""" Option 2:
-    Strips underscores from example file name only, adds to set with original
-    file name, and compares repo name to both example file name versions
-
-                    #return any(
-                    #    name.startswith(repo_name) for name in file_names
-                    #)
-
-                    ## long form only for showing results; 'any' above is the preferred version
-                    print(f"Checking {repo_name} against {file_name} versions:")
-                    for name in file_names:
-                        if name.startswith(repo_name):
-                            found = True
-
-                        print(
-                            f"\tExample file name: {name}\tMatch: {found}"
-                        )
-
-                    return found
-                    ##
-"""
 
                 lib_name_start = repo["name"].rfind("CircuitPython_") + 14
                 lib_name = repo["name"][lib_name_start:].lower()

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -636,14 +636,73 @@ class library_validator():
             if len(examples_list) < 1:
                 errors.append(ERROR_MISSING_EXAMPLE_FILES)
             else:
-                lib_name = (repo["name"][repo["name"].rfind("CircuitPython_")
-                            + 14:].lower())
+                def __check_lib_name(repo_name, file_name):
+                    """ Nested function to test example file names.
+                        Allows examples to either match the repo name,
+                        or have underscores separating the repo name.
+                    """
+                    file_names = set()
+                    file_names.add(file_name)
+
+                    name_split = file_name.split("_")
+                    name_rebuilt = ''.join(
+                        (part for part in name_split if ".py" not in part)
+                    )
+
+                    if name_rebuilt: # avoid adding things like 'simpletest.py' -> ''
+                        file_names.add(name_rebuilt)
+
+                    found = False
+
+""" Option 1:
+    Strips underscores from repo name and example name, and makes comparison
+
+                    repo_name_stripped = repo_name.replace("_", "")
+                    match = name_rebuilt.startswith(repo_name_stripped)
+                    print(
+                        f"Checking {repo_name} against {file_name}\n"
+                        f"\tRepo name stripped of '_': {repo_name_stripped}\n"
+                        f"\tRebuilt example name: {name_rebuilt}\n"
+                        f"\tMatch: {match}"
+                    )
+                    return match
+"""
+
+""" Option 2:
+    Strips underscores from example file name only, adds to set with original
+    file name, and compares repo name to both example file name versions
+
+                    #return any(
+                    #    name.startswith(repo_name) for name in file_names
+                    #)
+
+                    ## long form only for showing results; 'any' above is the preferred version
+                    print(f"Checking {repo_name} against {file_name} versions:")
+                    for name in file_names:
+                        if name.startswith(repo_name):
+                            found = True
+
+                        print(
+                            f"\tExample file name: {name}\tMatch: {found}"
+                        )
+
+                    return found
+                    ##
+"""
+
+                lib_name_start = repo["name"].rfind("CircuitPython_") + 14
+                lib_name = repo["name"][lib_name_start:].lower()
+
                 all_have_name = True
                 simpletest_exists = False
                 for example in examples_list:
-                    if (not example["name"].lower().startswith(lib_name)
-                        and example["name"].endswith(".py")):
-                            all_have_name = False
+                    if example["name"].endswith(".py"):
+                        check_lib_name = __check_lib_name(
+                            lib_name,
+                            example["name"].lower()
+                        )
+                        if not check_lib_name:
+                                all_have_name = False
                     if "simpletest" in example["name"].lower():
                         simpletest_exists = True
                 if not all_have_name:


### PR DESCRIPTION
This will allow underscores in example filenames, while not flagging them for not having the repo name in the example. There are two options included in this initial DRAFT PR.

**This draft will not work as submitted. Please let me know which of the following options is preferred.**

## Option 1:
Strips underscores from repo name and example name, and makes comparison. This would allow example filenames to have both _additional_ and _missing_ underscores when compared to the repo name. Examples:
```
Checking featherwing against featherwing_tempmotion_simpletest.py
        Repo name stripped of '_': featherwing
        Rebuilt example name: featherwingtempmotion
        Match: True
Checking display_shapes against display_shapes_simpletest.py
        Repo name stripped of '_': displayshapes
        Rebuilt example name: displayshapes
        Match: True
Checking display_button against display_button_customfont.py
        Repo name stripped of '_': displaybutton
        Rebuilt example name: displaybutton
        Match: True
Checking display_button against display_button_simpletest.py
        Repo name stripped of '_': displaybutton
        Rebuilt example name: displaybutton
        Match: True

---- Result ----
Example file(s) missing sensor/library name - 2
  * https://github.com/adafruit/Adafruit_CircuitPython_BNO055
  * https://github.com/adafruit/Adafruit_CircuitPython_AzureIoT
```

## Option 2:
Strips underscores from example file name only, adds to a set with the original
file name, and compares repo name to both example file name versions. This would only allow additional underscores in the example name, and not missing underscores. Examples:
```
Checking ble_broadcastnet against ble_broadcastnet_battery_level.py versions:
        Example file name: ble_broadcastnet_battery_level.py    Match: True
        Example file name: blebroadcastnetbattery       Match: True
Checking ble_broadcastnet against ble_broadcastnet_battery_level_neopixel.py versions:
        Example file name: blebroadcastnetbatterylevel  Match: False
        Example file name: ble_broadcastnet_battery_level_neopixel.py   Match: True
Checking ble_broadcastnet against ble_broadcastnet_blinka_bridge.py versions:
        Example file name: blebroadcastnetblinka        Match: False
        Example file name: ble_broadcastnet_blinka_bridge.py    Match: True
Checking adafruitio against adafruit_io_digital_out.py versions:
        Example file name: adafruit_io_digital_out.py   Match: False
        Example file name: adafruitiodigital    Match: True

---- Result ----
Example file(s) missing sensor/library name - 2
  * https://github.com/adafruit/Adafruit_CircuitPython_BNO055
  * https://github.com/adafruit/Adafruit_CircuitPython_AzureIoT
```