### PR TITLE
gather_insights: if weblate created a PR, name all authors inside

### DIFF
--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -855,7 +855,17 @@ class library_validator():
                         )
                         insights["merged_prs"].append(pr_link)
 
-                        insights["pr_merged_authors"].add(pr_info["user"]["login"])
+                        pr_author = pr_info["user"]["login"]
+                        if pr_author == "weblate":
+                            pr_commits = github.get(str(pr_info["url"]) + "/commits")
+                            if pr_commits.ok:
+                                for commit in pr_commits.json():
+                                    author = commit.get("author")
+                                    if author:
+                                        insights["pr_merged_authors"].add(author["login"])
+                        else:
+                            insights["pr_merged_authors"].add(pr_info["user"]["login"])
+
                         insights["pr_reviewers"].add(pr_info["merged_by"]["login"])
                         pr_reviews = github.get(str(pr_info["url"]) + "/reviews")
                         if pr_reviews.ok:


### PR DESCRIPTION
Weblate creates a single PR that can include contributions from multiple users.  The individual commits inside the PR have the actual contributor as the "author".  Ensure that these authors are credited individually.

Sometimes no "author" is listed; this appears to be because the gitcommit's author information does not match up to a github account. In one case, I see the author information is listed as "Anonymous <noreply@weblate.org>", which has no github user associated and ends up uncredited.

Testing performed: ran it locally and saw the translation author bergdahl credited.
```
Core
* 13 pull requests merged
  * 9 authors - bergdahl, LearnWeaver, hierophect, xobs, maholli, WarriorOfWire, DavePutz, jepler, xiongyihui
  * 4 reviewers - dhalbert, tannewt, jepler, hierophect
```