### PR TITLE
New Way To Get CircuitPython PyPI Download Stats

### DIFF
--- a/.github/workflows/reports_cron.yml
+++ b/.github/workflows/reports_cron.yml
@@ -60,6 +60,7 @@ jobs:
         continue-on-error: true
       - name: Run adabot.circuitpython_library_download_stats
         env:
+          ADABOT_GOOGLE_AUTH_STRING: ${{ secrets.ADABOT_GOOGLE_AUTH_STRING }}
           # LIB_DL_STATS_FILE is for future Bundle and PyPi download stats script
           LIB_DL_STATS_FILE: bin/adabot/library_download_stats_${{ steps.today.outputs.date }}.txt
         run: |

--- a/adabot/circuitpython_library_download_stats.py
+++ b/adabot/circuitpython_library_download_stats.py
@@ -76,6 +76,7 @@ def get_pypi_stats():
     """
     successful_stats = {}
     failed_stats = []
+    stats_result = None
 
     try:
         stats_query = PyPIBigQuery()
@@ -182,9 +183,9 @@ def run_stat_check():
             output_handler(row_format.format(*lib))
 
     else:
-        output_handler(" * Failed to retrieve stats:")
+        output_handler("Failed to retrieve PyPI download stats:")
         for fail in pypi_failures:
-            output_handler("   * {}".format(fail))
+            output_handler(" - {}".format(fail))
 
 if __name__ == "__main__":
     cmd_line_args = cmd_line_parser.parse_args()

--- a/adabot/circuitpython_library_download_stats.py
+++ b/adabot/circuitpython_library_download_stats.py
@@ -35,13 +35,28 @@ from adabot.lib.pypi_bigquery_stats import PyPIBigQuery
 from google.auth.exceptions import DefaultCredentialsError
 
 # Setup ArgumentParser
-cmd_line_parser = argparse.ArgumentParser(description="Adabot utility for CircuitPython Library download stats." \
-                                          " Provides stats for the Adafruit CircuitPython Bundle, and PyPi if available.",
-                                          prog="Adabot CircuitPython Libraries Download Stats")
-cmd_line_parser.add_argument("-o", "--output_file", help="Output log to the filename provided.",
-                             metavar="<OUTPUT FILENAME>", dest="output_file")
-cmd_line_parser.add_argument("-v", "--verbose", help="Set the level of verbosity printed to the command prompt."
-                             " Zero is off; One is on (default).", type=int, default=1, dest="verbose", choices=[0,1])
+cmd_line_parser = argparse.ArgumentParser(
+    prog="Adabot CircuitPython Libraries Download Stats",
+    description=(
+        "Adabot utility for CircuitPython Library download stats. Provides "
+        "stats for the Adafruit CircuitPython Bundle, and PyPi if available."
+    )
+)
+cmd_line_parser.add_argument(
+    "-o",
+    "--output_file",
+    help="Output log to the filename provided.",
+    metavar="<OUTPUT FILENAME>", dest="output_file"
+)
+cmd_line_parser.add_argument(
+    "-v",
+    "--verbose",
+    help="Set the level of verbosity printed to the command prompt.",
+    type=int,
+    default=1,
+    dest="verbose",
+    choices=[0, 1]
+)
 
 # Global variables
 output_filename = None
@@ -50,7 +65,9 @@ file_data = []
 
 # List containing libraries on PyPi that are not returned by the 'list_repos()' function,
 # i.e. are not named 'Adafruit_CircuitPython_'.
-PYPI_FORCE_NON_CIRCUITPYTHON = ["Adafruit-Blinka"]
+PYPI_FORCE_NON_CIRCUITPYTHON = [
+    "Adafruit-Blinka"
+]
 
 
 def get_pypi_stats():
@@ -85,9 +102,9 @@ def get_pypi_stats():
     return successful_stats, failed_stats
 
 def get_bundle_stats(bundle):
-    """ Returns the download stats for 'bundle'. Uses release tag names to compile download
-        stats for the last 7 days. This assumes an Adabot release within that time frame, and
-        that tag name(s) will be the date (YYYYMMDD).
+    """ The download stats for 'bundle'. Uses release tag names to compile
+        download stats for the last 7 days. This assumes an Adabot release
+        within that time frame, and that tag name(s) will be the date (YYYYMMDD).
     """
     stats_dict = {}
     bundle_stats = github.get("/repos/adafruit/" + bundle + "/releases")
@@ -100,8 +117,10 @@ def get_bundle_stats(bundle):
             release_date = datetime.date(int(release["tag_name"][:4]),
                                          int(release["tag_name"][4:6]),
                                          int(release["tag_name"][6:]))
-        except:
-            output_handler("Skipping release. Tag name invalid: {}".format(release["tag_name"]))
+        except Exception:
+            output_handler(
+                f"Skipping release. Tag name invalid: {release['tag_name']}"
+            )
             continue
         if (start_date - release_date).days > 7:
             break
@@ -125,9 +144,14 @@ def output_handler(message="", quiet=False):
 
 def run_stat_check():
     output_handler("Adafruit CircuitPython Library Download Stats")
-    output_handler("Report Date: {}".format(datetime.datetime.now().strftime("%d %B %Y, %I:%M%p")))
+    output_handler(
+        "Report Date: {}".format(
+            datetime.datetime.now().strftime("%d %B %Y, %I:%M%p")
+        )
+    )
     output_handler()
     output_handler("Adafruit_CircuitPython_Bundle downloads for the past week:")
+
     for stat in sorted(get_bundle_stats("Adafruit_CircuitPython_Bundle").items(),
                        key=operator.itemgetter(1), reverse=True):
         output_handler(" {0}: {1}".format(stat[0], stat[1]))

--- a/adabot/lib/pypi_bigquery_stats.py
+++ b/adabot/lib/pypi_bigquery_stats.py
@@ -1,0 +1,93 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2020 Michael Schroeder
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import json
+import os
+
+from google.cloud import bigquery
+from google.oauth2 import service_account
+
+BIGQ_QUERY_STRING = """SELECT
+  COUNT(*) AS num_downloads,
+  file.project AS `lib`,
+  details.installer.name AS `installer`
+FROM `the-psf.pypi.downloads*`
+WHERE
+  file.project LIKE 'adafruit-%'
+  AND details.installer.name = 'pip'
+  AND _TABLE_SUFFIX
+    BETWEEN FORMAT_DATE(
+      '%Y%m%d', DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY))
+    AND FORMAT_DATE('%Y%m%d', CURRENT_DATE())
+GROUP BY `lib`, `installer`
+ORDER BY `num_downloads` DESC
+"""
+
+class PyPIBigQuery:
+    """ Class to provide access to the PyPI stats Google BigQuery, provided
+        by PPA's Linehaul service.
+
+        Note: requires GCP service account credentials info to be available
+        as a JSON-string enrivornment variable 'ADABOT_GOOGLE_AUTH_STRING'.
+    """
+
+    def __init__(self):
+        creds_info = json.loads(
+            os.environ.get("ADABOT_GOOGLE_AUTH_STRING", "")
+        )
+        credentials = service_account.Credentials.from_service_account_info(
+            creds_info
+        )
+        self._client = bigquery.Client(credentials=credentials)
+        self._results = {}
+
+    def query(self):
+        """ Initiates a query, waits for the query to finish, and stores
+            the results into `self._result` (accessed via ``results`` method).
+
+            :returns: Query job result status as a boolean
+        """
+        query_job = self._client.query(BIGQ_QUERY_STRING)
+        results = query_job.result()
+
+        if results:
+            results_to_dict = {}
+            for row in results:
+                lib = row.get("lib")
+                num_dl = int(row.get("num_downloads", 0))
+                results_to_dict[lib] = num_dl
+
+            self._results = results_to_dict
+            results = True
+        else:
+            self._results = {}
+            results = False
+
+        return results
+
+    @property
+    def results(self):
+        """ The results of the last query.
+
+            :returns: Dict[str: int] as '{lib_name: downloads}'
+        """
+        return self._results

--- a/adabot/lib/pypi_bigquery_stats.py
+++ b/adabot/lib/pypi_bigquery_stats.py
@@ -25,6 +25,7 @@ import os
 
 from google.cloud import bigquery
 from google.oauth2 import service_account
+from google.auth.exceptions import DefaultCredentialsError
 
 BIGQ_QUERY_STRING = """SELECT
   COUNT(*) AS num_downloads,
@@ -52,8 +53,11 @@ class PyPIBigQuery:
 
     def __init__(self):
         creds_info = json.loads(
-            os.environ.get("ADABOT_GOOGLE_AUTH_STRING", "")
+            os.environ.get("ADABOT_GOOGLE_AUTH_STRING", "{}")
         )
+        if not creds_info:
+            raise DefaultCredentialsError("Credentials not found.")
+
         credentials = service_account.Credentials.from_service_account_info(
             creds_info
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 certifi==2017.11.5
 chardet==3.0.4
+google-cloud-bigquery==1.25.0
 idna==2.6
 packaging==20.3
 redis==2.10.6


### PR DESCRIPTION
Fixes #162.

## PR Info
This moves us off of using `pypistats.org`. It now directly accesses the Google BigQuery that PPA's Linehaul project streams download info into.

This implementation ignores stats that aren't installed via `pip`.

The SQL query as formulated takes about 20GB/query. The first 1TB of data processed with BigQuery each month is free, so at this size 48 queries can be made before the GCP account is billed for BigQuery interaction. Subject to change of course... https://cloud.google.com/bigquery#section-10

@theacodes tagging you, since you likely have some experience in this area, and I would love your insights if you're willing.

## Setup
A few things need to happen before this can run in the nightly Actions job. These were followed from https://packaging.python.org/guides/analyzing-pypi-package-downloads/#getting-set-up, and some personal research:
1. Establish a Google Cloud Platform account for Adabot (if doesn't exist). https://cloud.google.com/
2. Enable BigQuery, and create a project that includes dataset `the-psf`. https://cloud.google.com/bigquery
3. Create a Service Account Key for the account, with access to BigQuery. https://cloud.google.com/docs/authentication/getting-started
4. Using the resulting JSON file from creating the Service Account Key, copy the information into a GitHub secret named `ADABOT_GOOGLE_AUTH_STRING`. The JSON string should be enclosed in single-quotes, and only remove newlines from the JSON formatting. Do not remove the newlines from the RSA key. 

Example for number 4:
```
{
  "type": "service_account",
  "project_id": "project-id-12345",
  "private_key_id": "a_private_key_id",
  "private_key": "-----BEGIN PRIVATE KEY-----\n[...key...]==\n-----END PRIVATE KEY-----\n",
  "client_email": "bigquery-pypi@stuff.iam.gserviceaccount.com",
  "client_id": "numbers",
  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
  "token_uri": "https://oauth2.googleapis.com/token",
  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
  "client_x509_cert_url": "https://longgggurl.com"
}
```
... becomes (note: the `\n` remain in the RSA key):
```py
'{"type": "service_account","project_id": "project-id-12345","private_key_id": "a_private_key_id","private_key": "-----BEGIN PRIVATE KEY-----\n[...key...]==\n-----END PRIVATE KEY-----\n","client_email": "bigquery-pypi@stuff.iam.gserviceaccount.com",[...]}'
```

## Local Operation Example
```
(.env) ~/Dev/adabot/adabot:$> python3 -m adabot.circuitpython_library_download_stats
Adafruit CircuitPython Library Download Stats
Report Date: 24 June 2020, 02:12PM

Adafruit_CircuitPython_Bundle downloads for the past week:
 adafruit-circuitpython-bundle-5.x-mpy: 604
 adafruit-circuitpython-bundle-py: 156
 adafruit-circuitpython-bundle-4.x-mpy: 152
 adafruit-circuitpython-bundle-examples: 62

Adafruit CircuitPython Library PyPi downloads:
| Library                                              | Last Week |   
|:-------                                              |:--------: |   
| Adafruit-Blinka                                      | 1656 |        
| adafruit-circuitpython-busdevice                     | 1017 |        
| adafruit-circuitpython-mcp230xx                      | 293 |         
| adafruit-circuitpython-bmp280                        | 274 |         
| adafruit-circuitpython-register                      | 235 |         
| adafruit-circuitpython-neopixel                      | 193 |         
| adafruit-circuitpython-seesaw                        | 182 |
[....]
```