### PR TITLE
Print a warning for repos without descriptions

### DIFF
--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -230,13 +230,14 @@ def run_library_checks(validators, bundle_submodules, latest_pylint, kw_args):
         int(pr_sort_re.search(pr).group(1)) for pr in lib_insights["open_prs"]
         if pr_sort_re.search(pr) is not None
     ]
-    output_handler(
-        "  * {0} open pull requests (Oldest: {1}, Newest: {2})".format(
-            len(lib_insights["open_prs"]),
-            max(open_pr_days),
-            max((min(open_pr_days), 1)) # ensure the minumum is '1'
+    if len(lib_insights["open_prs"]) != 0:
+        output_handler(
+            "  * {0} open pull requests (Oldest: {1}, Newest: {2})".format(
+                len(lib_insights["open_prs"]),
+                max(open_pr_days),
+                max((min(open_pr_days), 1)) # ensure the minumum is '1'
+            )
         )
-    )
     output_handler("Library updates in the last seven days:")
     if len(new_libs) != 0:
         output_handler("**New Libraries**")

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -56,6 +56,7 @@ ERROR_PYFILE_MISSING_ERRNO = ".py file contains reference to import uerrno" \
 " without reference to import errno.  See issue " \
 "https://github.com/adafruit/circuitpython/issues/1582"
 ERROR_MISMATCHED_READTHEDOCS = "Mismatched readthedocs.yml"
+ERROR_MISSING_DESCRIPTION = "Missing repository description"
 ERROR_MISSING_EXAMPLE_FILES = "Missing .py files in examples folder"
 ERROR_MISSING_EXAMPLE_FOLDER = "Missing examples folder"
 ERROR_EXAMPLE_MISSING_SENSORNAME = "Example file(s) missing sensor/library name"
@@ -208,6 +209,9 @@ class library_validator():
             repo_fields = response.json()
 
         errors = []
+
+        if not repo_fields.get("description"):
+            errors.append(ERROR_MISSING_DESCRIPTION)
 
         if repo_fields.get("has_wiki"):
             errors.append(ERROR_WIKI_DISABLED)


### PR DESCRIPTION
These descriptions improve social shares, and possibly search results.

Missing repository description - 60
  * https://github.com/adafruit/Adafruit_CircuitPython_SK9822
  * https://github.com/adafruit/Adafruit_CircuitPython_Debug_Bus_Device
  * https://github.com/adafruit/Adafruit_CircuitPython_Debug_SPI
  * https://github.com/adafruit/Adafruit_CircuitPython_74HC595
  * https://github.com/adafruit/Adafruit_CircuitPython_ADXL34x
  * https://github.com/adafruit/Adafruit_CircuitPython_APDS9500
  * https://github.com/adafruit/Adafruit_CircuitPython_BD3491FS
  * https://github.com/adafruit/Adafruit_CircuitPython_BH1750
  * https://github.com/adafruit/Adafruit_CircuitPython_BluefruitConnect
  * https://github.com/adafruit/Adafruit_CircuitPython_BMP3XX
  * https://github.com/adafruit/Adafruit_CircuitPython_Debug_I2C
  * https://github.com/adafruit/Adafruit_CircuitPython_DS1841
  * https://github.com/adafruit/Adafruit_CircuitPython_DS3502
  * https://github.com/adafruit/Adafruit_CircuitPython_ESP_ATcontrol
  * https://github.com/adafruit/Adafruit_CircuitPython_FRAM
  * https://github.com/adafruit/Adafruit_CircuitPython_framebuf
  * https://github.com/adafruit/Adafruit_CircuitPython_HTS221
  * https://github.com/adafruit/Adafruit_CircuitPython_HX8357
  * https://github.com/adafruit/Adafruit_CircuitPython_ICM20X
  * https://github.com/adafruit/Adafruit_CircuitPython_INA260
  * https://github.com/adafruit/Adafruit_CircuitPython_IterTools
  * https://github.com/adafruit/Adafruit_CircuitPython_LIS2MDL
  * https://github.com/adafruit/Adafruit_CircuitPython_LIS331
  * https://github.com/adafruit/Adafruit_CircuitPython_LIS3MDL
  * https://github.com/adafruit/Adafruit_CircuitPython_LPS2X
  * https://github.com/adafruit/Adafruit_CircuitPython_LPS35HW
  * https://github.com/adafruit/Adafruit_CircuitPython_LSM303_Accel
  * https://github.com/adafruit/Adafruit_CircuitPython_LSM303DLH_Mag
  * https://github.com/adafruit/Adafruit_CircuitPython_MAX31856
  * https://github.com/adafruit/Adafruit_CircuitPython_MCP4728
  * https://github.com/adafruit/Adafruit_CircuitPython_MIDI
  * https://github.com/adafruit/Adafruit_CircuitPython_miniesptool
  * https://github.com/adafruit/Adafruit_CircuitPython_MLX90614
  * https://github.com/adafruit/Adafruit_CircuitPython_MPL115A2
  * https://github.com/adafruit/Adafruit_CircuitPython_MSA301
  * https://github.com/adafruit/Adafruit_CircuitPython_PCF8591
  * https://github.com/adafruit/Adafruit_CircuitPython_PyBadger
  * https://github.com/adafruit/Adafruit_CircuitPython_RockBlock
  * https://github.com/adafruit/Adafruit_CircuitPython_RPLIDAR
  * https://github.com/adafruit/Adafruit_CircuitPython_SHTC3
  * https://github.com/adafruit/Adafruit_CircuitPython_SSD1305
  * https://github.com/adafruit/Adafruit_CircuitPython_SSD1331
  * https://github.com/adafruit/Adafruit_CircuitPython_SSD1351
  * https://github.com/adafruit/Adafruit_CircuitPython_TLV493D
  * https://github.com/adafruit/Adafruit_CircuitPython_TMP006
  * https://github.com/adafruit/Adafruit_CircuitPython_TPA2016
  * https://github.com/adafruit/Adafruit_CircuitPython_VCNL4040
  * https://github.com/adafruit/Adafruit_CircuitPython_VEML7700
  * https://github.com/adafruit/Adafruit_CircuitPython_RA8875
  * https://github.com/adafruit/Adafruit_CircuitPython_GFX
  * https://github.com/adafruit/Adafruit_CircuitPython_PN532
  * https://github.com/adafruit/Adafruit_CircuitPython_CLUE
  * https://github.com/adafruit/Adafruit_CircuitPython_DPS310
  * https://github.com/adafruit/Adafruit_CircuitPython_BitbangIO
  * https://github.com/adafruit/Adafruit_CircuitPython_MPU6050
  * https://github.com/adafruit/Adafruit_CircuitPython_Pypixelbuf
  * https://github.com/adafruit/Adafruit_CircuitPython_AS7341
  * https://github.com/adafruit/Adafruit_CircuitPython_LSM6DS
  * https://github.com/adafruit/Adafruit_CircuitPython_PCT2075
  * https://github.com/adafruit/Adafruit_CircuitPython_MS8607
