### PR TITLE
Add Validator To Run Pylint On Libraries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ certifi==2017.11.5
 chardet==3.0.4
 idna==2.6
 packaging==20.3
+pylint
 redis==2.10.6
 requests==2.20.0
 sh==1.12.14


### PR DESCRIPTION
Fixes #184

```
(.env) ~/Dev/adabot/adabot:$> python -m adabot.circuitpython_libraries -v "validate_passes_linting" -e 999
Running CircuitPython Library checks...
Report Date: 05 September 2020, 01:39PM
 - Depth for listing libraries with errors: 999
 - These validators will run: validate_passes_linting

Latest pylint is: 2.6.0
Found 260 repos to check.
Found 239 submodules in the bundle.

Failed PyLint checks - 48
  * https://github.com/adafruit/Adafruit_CircuitPython_JTAG
  * https://github.com/adafruit/Adafruit_CircuitPython_ATECC
  * https://github.com/adafruit/Adafruit_CircuitPython_AWS_IOT
  * https://github.com/adafruit/Adafruit_CircuitPython_AzureIoT
  * https://github.com/adafruit/Adafruit_CircuitPython_BLE_Eddystone
  * https://github.com/adafruit/Adafruit_CircuitPython_BLE_Radio
  * https://github.com/adafruit/Adafruit_CircuitPython_CPython
  * https://github.com/adafruit/Adafruit_CircuitPython_ESP_ATcontrol
  * https://github.com/adafruit/Adafruit_CircuitPython_FONA
  * https://github.com/adafruit/Adafruit_CircuitPython_hashlib
  * https://github.com/adafruit/Adafruit_CircuitPython_Hue
  * https://github.com/adafruit/Adafruit_CircuitPython_JWT
  * https://github.com/adafruit/Adafruit_CircuitPython_LIFX
  * https://github.com/adafruit/Adafruit_CircuitPython_PYOA
  * https://github.com/adafruit/Adafruit_CircuitPython_RPLIDAR
  * https://github.com/adafruit/Adafruit_CircuitPython_TrellisM4
  * https://github.com/adafruit/Adafruit_CircuitPython_turtle
  * https://github.com/adafruit/Adafruit_CircuitPython_AVRprog
  * https://github.com/adafruit/Adafruit_CircuitPython_Wiznet5k
  * https://github.com/adafruit/Adafruit_CircuitPython_BH1750
  * https://github.com/adafruit/Adafruit_CircuitPython_AS7341
  * https://github.com/adafruit/Adafruit_CircuitPython_TinyLoRa
  * https://github.com/adafruit/Adafruit_CircuitPython_GC_IOT_Core
  * https://github.com/adafruit/Adafruit_CircuitPython_BluefruitConnect
  * https://github.com/adafruit/Adafruit_CircuitPython_MCP3xxx
  * https://github.com/adafruit/Adafruit_CircuitPython_RA8875
  * https://github.com/adafruit/Adafruit_CircuitPython_GFX
  * https://github.com/adafruit/Adafruit_CircuitPython_Pypixelbuf
  * https://github.com/adafruit/Adafruit_CircuitPython_Register
  * https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
  * https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT
  * https://github.com/adafruit/Adafruit_CircuitPython_BNO055
  * https://github.com/adafruit/Adafruit_CircuitPython_RSA
  * https://github.com/adafruit/Adafruit_CircuitPython_MachXO
  * https://github.com/adafruit/Adafruit_CircuitPython_EPD
  * https://github.com/adafruit/Adafruit_CircuitPython_PM25
  * https://github.com/adafruit/Adafruit_CircuitPython_Debouncer
  * https://github.com/adafruit/Adafruit_CircuitPython_BLE_Adafruit
  * https://github.com/adafruit/Adafruit_CircuitPython_Requests
  * https://github.com/adafruit/Adafruit_CircuitPython_AdafruitIO
  * https://github.com/adafruit/Adafruit_CircuitPython_MIDI
  * https://github.com/adafruit/Adafruit_CircuitPython_ImageLoad
  * https://github.com/adafruit/Adafruit_CircuitPython_Motor
  * https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI
  * https://github.com/adafruit/Adafruit_CircuitPython_MCP2515
  * https://github.com/adafruit/Adafruit_CircuitPython_Bitmap_Font
  * https://github.com/adafruit/Adafruit_CircuitPython_framebuf
  * https://github.com/adafruit/Adafruit_CircuitPython_BNO080
```