### PR TITLE
Adding docs links to lib md

### DIFF
--- a/adabot/circuitpython_bundle.py
+++ b/adabot/circuitpython_bundle.py
@@ -80,8 +80,12 @@ def check_lib_links_md(bundle_path):
         pypi_name = ""
         if common_funcs.repo_is_on_pypi({"name" : url_name}):
             pypi_name = " ([PyPi](https://pypi.org/project/{}))".format(url_name.replace("_", "-").lower())
+        docs_name = ""
+        docs_link = common_funcs.get_docs_link(bundle_path, submodule)
+        if docs_link:
+            docs_name = f" \([Docs]({docs_link}))"
         title = url_name.replace("_", " ")
-        list_line = "* [{0}]({1}){2}".format(title, url, pypi_name)
+        list_line = "* [{0}]({1}){2}{3}".format(title, url, pypi_name, docs_name)
         if list_line not in read_lines:
             updates_made.append(url_name)
         if "drivers" in submodule[1]["path"]:
@@ -371,12 +375,12 @@ if __name__ == "__main__":
     for bundle in bundles:
         bundle_path = os.path.join(directory, bundle)
         try:
-            fetch_bundle(bundle, bundle_path)
+            #fetch_bundle(bundle, bundle_path)
             update_info = update_bundle(bundle_path)
-            if update_info:
-                commit_updates(bundle_path, update_info)
-                push_updates(bundle_path)
-            new_release(bundle, bundle_path)
+            #if update_info:
+            #    commit_updates(bundle_path, update_info)
+            #    push_updates(bundle_path)
+            #new_release(bundle, bundle_path)
         except RuntimeError as e:
             print("Failed to update and release:", bundle)
             print(e)

--- a/adabot/circuitpython_bundle.py
+++ b/adabot/circuitpython_bundle.py
@@ -375,12 +375,12 @@ if __name__ == "__main__":
     for bundle in bundles:
         bundle_path = os.path.join(directory, bundle)
         try:
-            #fetch_bundle(bundle, bundle_path)
+            fetch_bundle(bundle, bundle_path)
             update_info = update_bundle(bundle_path)
-            #if update_info:
-            #    commit_updates(bundle_path, update_info)
-            #    push_updates(bundle_path)
-            #new_release(bundle, bundle_path)
+            if update_info:
+                commit_updates(bundle_path, update_info)
+                push_updates(bundle_path)
+            new_release(bundle, bundle_path)
         except RuntimeError as e:
             print("Failed to update and release:", bundle)
             print(e)

--- a/adabot/lib/common_funcs.py
+++ b/adabot/lib/common_funcs.py
@@ -202,6 +202,19 @@ def list_repos(*, include_repos=None):
 
     return repos
 
+def get_docs_link(bundle_path, submodule):
+    try:
+        f = open(f"{bundle_path}/{submodule[1]['path']}/README.rst", 'r')
+        lines = f.read().split("\n")
+        f.close()
+        for i in range(10):
+            if "target" in lines[i] and "readthedocs" in lines[i]:
+                return lines[i].replace("    :target: ", "")
+        return None
+    except FileNotFoundError:
+        # didn't find readme
+        return None
+
 def repo_is_on_pypi(repo):
     """returns True when the provided repository is in pypi"""
     is_on = False


### PR DESCRIPTION
See issue for some history on this: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/issues/262 also this PR: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/pull/265

There was an attempt to add these docs link manually in the bundle repo. But it turned out that it needs to be done here in adabot.

This PR updates the script to include a docs link formatted the same as that original PR. I spot checked a few of the ones in the resulting md file and they were working correctly, but I did not do an exhaustive test of them.

Here is the md file that was generated when I tested this script locally:
[circuitpython_library_list.md.txt](https://github.com/adafruit/adabot/files/5503885/circuitpython_library_list.md.txt)

