### PR TITLE
Change Verification Method of .readthedocs.yml

### DIFF
--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -757,8 +757,6 @@ class library_validator():
                     if name_rebuilt: # avoid adding things like 'simpletest.py' -> ''
                         file_names.add(name_rebuilt)
 
-                    found = False
-
                     return any(
                         name.startswith(repo_name) for name in file_names
                     )
@@ -786,7 +784,7 @@ class library_validator():
             errors.append(ERROR_MISSING_EXAMPLE_FOLDER)
 
         # first location .py files whose names begin with "adafruit_"
-        re_str = re.compile('adafruit\_[\w]*\.py')
+        re_str = re.compile(r'adafruit\_[\w]*\.py')
         pyfiles = ([x["download_url"] for x in content_list
                    if re_str.fullmatch(x["name"])])
         for pyfile in pyfiles:
@@ -794,7 +792,7 @@ class library_validator():
             errors.extend(self._validate_py_for_u_modules(repo, pyfile))
 
         # now location any directories whose names begin with "adafruit_"
-        re_str = re.compile('adafruit\_[\w]*')
+        re_str = re.compile(r'adafruit\_[\w]*')
         for adir in dirs:
             if re_str.fullmatch(adir):
                 # retrieve the files in that directory

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ chardet==3.0.4
 idna==2.6
 packaging==20.3
 pylint
+pyyaml==5.4.1
 redis==2.10.6
 requests==2.20.0
 sh==1.12.14


### PR DESCRIPTION
Fixes #215

This grabs `.readthedocs.yml` content from `adafruit/cookiecutter-adafruit-circuitpython`, parses the YAML, and then compares each library's  parsed YAML to the cookicutter version.

Originally, I used some discovery via the GH API to get the cookiecutter version in an effort to avoid hardcoding the URL and being "futureproof". However, the code was cumbersome and essentially only used once per session. So...I hardcoded it. _Should_ be an easy update if the file/URL path ever changes.

An alternative, that doesn't involve additional dependencies, would be to just compare the raw text. Another benefit to raw text comparison is that it would also compare the license info.

There's no discernable increase in processing times, and there are no increases to GH API requests.

I would like a better system than `print()` to report _internal_ errors; but this is a larger scope than this PR. I'll give it some more thought, and might file an issue.