### PR TITLE
Added python 3.7 CI patch

### DIFF
--- a/patches/0001-Moved-CI-to-Python-3.7.patch
+++ b/patches/0001-Moved-CI-to-Python-3.7.patch
@@ -1,0 +1,22 @@
+From 8aae58251db367121928397025fcd7a487e1ba9c Mon Sep 17 00:00:00 2001
+From: Dylan Herrada <33632497+dherrada@users.noreply.github.com>
+Date: Thu, 20 May 2021 16:13:41 -0400
+Subject: [PATCH] Moved CI to Python 3.7
+
+---
+ .github/workflows/build.yml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/.github/workflows/build.yml b/.github/workflows/build.yml
+index 0a44310..a9516b8 100644
+--- a/.github/workflows/build.yml
++++ b/.github/workflows/build.yml
+@@ -25 +25 @@ jobs:
+-    - name: Set up Python 3.6
++    - name: Set up Python 3.7
+@@ -28 +28 @@ jobs:
+-        python-version: 3.6
++        python-version: 3.7
+-- 
+2.25.1
+


### PR DESCRIPTION
We're doing this because a number of libraries are failing because they can't find libraries that are in Python 3.7 but not in 3.6