### PR TITLE
Fix Output File Generation For Reports

### DIFF
--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -21,13 +21,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+import argparse
 import copy
 import datetime
+import inspect
+import logging
 import re
 import sys
-import argparse
 import traceback
-import inspect
 
 import requests
 
@@ -38,6 +39,14 @@ from adabot.lib import common_funcs
 from adabot.lib import assign_hacktober_label as hacktober
 from adabot.lib import blinka_funcs
 from adabot import circuitpython_library_download_stats as dl_stats
+
+logger = logging.getLogger(__name__)
+ch = logging.StreamHandler(stream=sys.stdout)
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(message)s',
+    handlers=[ch]
+)
 
 # Setup ArgumentParser
 cmd_line_parser = argparse.ArgumentParser(
@@ -81,13 +90,6 @@ bundle_submodules = []
 # Load the latest pylint version
 latest_pylint = "2.0.1"
 
-# Logging output filename and data
-output_filename = None
-file_data = []
-# Verbosity level
-verbosity = 1
-github_token = False
-
 # Functions to run on repositories to validate their state.  By convention these
 # return a list of string errors for the specified repository (a dictionary
 # of Github API repository object state).
@@ -114,17 +116,17 @@ def run_library_checks(validators, bundle_submodules, latest_pylint, kw_args, er
     pylint_info = pypi.get("/pypi/pylint/json")
     if pylint_info and pylint_info.ok:
         latest_pylint = pylint_info.json()["info"]["version"]
-    output_handler("Latest pylint is: {}".format(latest_pylint))
+    logger.info("Latest pylint is: {}".format(latest_pylint))
 
     repos = common_funcs.list_repos(include_repos=tuple(blinka_repos) +
                                         ("CircuitPython_Community_Bundle",
                                         "cookiecutter-adafruit-circuitpython"))
 
-    output_handler("Found {} repos to check.".format(len(repos)))
+    logger.info("Found {} repos to check.".format(len(repos)))
     bundle_submodules = common_funcs.get_bundle_submodules()
-    output_handler("Found {} submodules in the bundle.".format(len(bundle_submodules)))
+    logger.info("Found {} submodules in the bundle.".format(len(bundle_submodules)))
     github_user = common_funcs.whois_github_user()
-    output_handler("Running GitHub checks as " + github_user)
+    logger.info("Running GitHub checks as " + github_user)
     need_work = 0
 
     lib_insights = common_funcs.InsightData()
@@ -155,7 +157,7 @@ def run_library_checks(validators, bundle_submodules, latest_pylint, kw_args, er
                     # check for an error occurring in the valiator module
                     if error == cirpy_lib_vals.ERROR_OUTPUT_HANDLER:
                         #print(errors, "repo output handler error:", validator.output_file_data)
-                        output_handler(", ".join(validator.output_file_data))
+                        logger.info(", ".join(validator.output_file_data))
                         validator.output_file_data.clear()
                     if error not in repos_by_error:
                         repos_by_error[error] = []
@@ -178,7 +180,7 @@ def run_library_checks(validators, bundle_submodules, latest_pylint, kw_args, er
             print("insights error")
             for error in errors:
                 if error == cirpy_lib_vals.ERROR_OUTPUT_HANDLER:
-                    output_handler(", ".join(validator.output_file_data))
+                    logger.info(", ".join(validator.output_file_data))
                     validator.output_file_data.clear()
 
         # get a list of new & updated libraries for the last week
@@ -189,76 +191,76 @@ def run_library_checks(validators, bundle_submodules, latest_pylint, kw_args, er
             elif check_releases == "updated":
                 updated_libs[repo["name"]] = repo["html_url"]
 
-    output_handler()
-    output_handler("State of CircuitPython + Libraries + Blinka")
+    logger.info("")
+    logger.info("State of CircuitPython + Libraries + Blinka")
 
-    output_handler("### Overall")
+    logger.info("### Overall")
     print_pr_overview(lib_insights, core_insights, blinka_insights)
     print_issue_overview(lib_insights, core_insights, blinka_insights)
 
-    output_handler()
-    output_handler("### Core")
+    logger.info("")
+    logger.info("### Core")
     print_pr_overview(core_insights)
-    output_handler("* {} open pull requests".format(len(core_insights["open_prs"])))
+    logger.info("* {} open pull requests".format(len(core_insights["open_prs"])))
     sorted_prs = sorted(core_insights["open_prs"],
                         key=lambda days: int(pr_sort_re.search(days).group(1)),
                         reverse=True)
     for pr in sorted_prs:
-        output_handler("  * {}".format(pr))
+        logger.info("  * {}".format(pr))
     print_issue_overview(core_insights)
-    output_handler("* {} open issues".format(len(core_insights["open_issues"])))
-    output_handler("  * https://github.com/adafruit/circuitpython/issues")
-    output_handler("* {} active milestones".format(len(core_insights["milestones"])))
+    logger.info("* {} open issues".format(len(core_insights["open_issues"])))
+    logger.info("  * https://github.com/adafruit/circuitpython/issues")
+    logger.info("* {} active milestones".format(len(core_insights["milestones"])))
     ms_count = 0
     for milestone in sorted(core_insights["milestones"].keys()):
         ms_count += core_insights["milestones"][milestone]
-        output_handler("  * {0}: {1} open issues".format(milestone,
+        logger.info("  * {0}: {1} open issues".format(milestone,
                                                          core_insights["milestones"][milestone]))
-    output_handler("  * {} issues not assigned a milestone".format(len(core_insights["open_issues"]) - ms_count))
-    output_handler()
+    logger.info("  * {} issues not assigned a milestone".format(len(core_insights["open_issues"]) - ms_count))
+    logger.info("")
 
     ## temporarily disabling core download stats:
     #  - GitHub API has been broken, due to the number of release artifacts
     #  - Release asset delivery is being moved to AWS CloudFront/S3
     #print_circuitpython_download_stats()
-    output_handler(
+    logger.info(
         "* Core download stats available at https://circuitpython.org/stats"
     )
 
-    output_handler()
-    output_handler("### Libraries")
+    logger.info("")
+    logger.info("### Libraries")
     print_pr_overview(lib_insights)
-    output_handler("  * Merged pull requests:")
+    logger.info("  * Merged pull requests:")
     sorted_prs = sorted(lib_insights["merged_prs"],
                         key=lambda days: int(close_pr_sort_re.search(days).group(1)),
                         reverse=True)
     for pr in sorted_prs:
-        output_handler("    * {}".format(pr))
+        logger.info("    * {}".format(pr))
     print_issue_overview(lib_insights)
-    output_handler("* https://circuitpython.org/contributing")
-    output_handler("  * {} open issues".format(len(lib_insights["open_issues"])))
-    output_handler("  * {} good first issues".format(lib_insights["good_first_issues"]))
+    logger.info("* https://circuitpython.org/contributing")
+    logger.info("  * {} open issues".format(len(lib_insights["open_issues"])))
+    logger.info("  * {} good first issues".format(lib_insights["good_first_issues"]))
     open_pr_days = [
         int(pr_sort_re.search(pr).group(1)) for pr in lib_insights["open_prs"]
         if pr_sort_re.search(pr) is not None
     ]
     if len(lib_insights["open_prs"]) != 0:
-        output_handler(
+        logger.info(
             "  * {0} open pull requests (Oldest: {1}, Newest: {2})".format(
                 len(lib_insights["open_prs"]),
                 max(open_pr_days),
                 max((min(open_pr_days), 1)) # ensure the minumum is '1'
             )
         )
-    output_handler("Library updates in the last seven days:")
+    logger.info("Library updates in the last seven days:")
     if len(new_libs) != 0:
-        output_handler("**New Libraries**")
+        logger.info("**New Libraries**")
         for new in new_libs:
-            output_handler(" * [{}]({})".format(new, new_libs[new]))
+            logger.info(" * [{}]({})".format(new, new_libs[new]))
     if len(updated_libs) != 0:
-        output_handler("**Updated Libraries**")
+        logger.info("**Updated Libraries**")
         for updated in updated_libs:
-            output_handler(" * [{}]({})".format(updated, updated_libs[updated]))
+            logger.info(" * [{}]({})".format(updated, updated_libs[updated]))
 
     if len(validators) != 0:
         lib_repos = []
@@ -267,44 +269,37 @@ def run_library_checks(validators, bundle_submodules, latest_pylint, kw_args, er
                 repo["name"].startswith("Adafruit_CircuitPython")):
                     lib_repos.append(repo)
 
-        output_handler("{} out of {} repos need work.".format(need_work,
+        logger.info("{} out of {} repos need work.".format(need_work,
                                                               len(lib_repos)))
 
         list_repos_for_errors = [cirpy_lib_vals.ERROR_NOT_IN_BUNDLE]
-        output_handler()
+        logger.info("")
         for error in sorted(repos_by_error):
             if not repos_by_error[error]:
                 continue
-            output_handler()
+            logger.info("")
             error_count = len(repos_by_error[error])
-            output_handler("{} - {}".format(error, error_count))
+            logger.info("{} - {}".format(error, error_count))
             if error_count <= error_depth or error in list_repos_for_errors:
-                output_handler("\n".join(["  * " + x for x in repos_by_error[error]]))
+                logger.info("\n".join(["  * " + x for x in repos_by_error[error]]))
 
-    output_handler()
-    output_handler("### Blinka")
+    logger.info("")
+    logger.info("### Blinka")
     print_pr_overview(blinka_insights)
-    output_handler("* {} open pull requests".format(len(blinka_insights["open_prs"])))
+    logger.info("* {} open pull requests".format(len(blinka_insights["open_prs"])))
     sorted_prs = sorted(blinka_insights["open_prs"],
                         key=lambda days: int(pr_sort_re.search(days).group(1)),
                         reverse=True)
     for pr in sorted_prs:
-        output_handler("  * {}".format(pr))
+        logger.info("  * {}".format(pr))
     print_issue_overview(blinka_insights)
-    output_handler("* {} open issues".format(len(blinka_insights["open_issues"])))
-    output_handler("  * https://github.com/adafruit/Adafruit_Blinka/issues")
+    logger.info("* {} open issues".format(len(blinka_insights["open_issues"])))
+    logger.info("  * https://github.com/adafruit/Adafruit_Blinka/issues")
     blinka_dl = dl_stats.piwheels_stats().get('adafruit-blinka', {}).get("month", "N/A")
-    output_handler("* Piwheels Downloads in the last month: {}".format(blinka_dl))
-    output_handler(
+    logger.info("* Piwheels Downloads in the last month: {}".format(blinka_dl))
+    logger.info(
         "Number of supported boards: {}".format(blinka_funcs.board_count())
     )
-
-def output_handler(message="", quiet=False):
-    """Handles message output to prompt/file for print_*() functions."""
-    if output_filename is not None:
-        file_data.append(message)
-    if verbosity and not quiet:
-        print(message)
 
 def print_circuitpython_download_stats():
     """Gather and report analytics on the main CircuitPython repository."""
@@ -317,13 +312,13 @@ def print_circuitpython_download_stats():
     try:
         response = github.get("/repos/adafruit/circuitpython/releases")
     except (ValueError, RuntimeError):
-        output_handler(
+        logger.info(
             "Core CircuitPython GitHub download statistics request failed."
         )
         return
 
     if not response.ok:
-        output_handler(
+        logger.info(
             "Core CircuitPython GitHub download statistics request failed."
         )
         return
@@ -387,10 +382,10 @@ def print_circuitpython_download_stats():
                 total[release["tag_name"]] = 0
             total[release["tag_name"]] += count
 
-    output_handler("Number of supported boards: {}".format(len(by_board)))
-    output_handler()
-    output_handler("Download stats by board:")
-    output_handler()
+    logger.info("Number of supported boards: {}".format(len(by_board)))
+    logger.info("")
+    logger.info("Download stats by board:")
+    logger.info("")
     by_board_list = [["Board", "{}".format(stable_tag.strip(" ")), "{}".format(prerelease_tag.strip(" "))],]
     for board in sorted(by_board.items()):
         by_board_list.append([str(board[0]),
@@ -420,11 +415,11 @@ def print_circuitpython_download_stats():
                           "{}".format("-"*(long_col[2]))]))
 
     for row in by_board_list:
-        output_handler(row_format.format(*row))
-    output_handler()
+        logger.info(row_format.format(*row))
+    logger.info("")
 
-    output_handler("Download stats by language:")
-    output_handler()
+    logger.info("Download stats by language:")
+    logger.info("")
     by_lang_list = [["Board", "{}".format(stable_tag.strip(" ")), "{}".format(prerelease_tag.strip(" "))],]
     for board in sorted(by_language.items()):
         by_lang_list.append([str(board[0]),
@@ -454,26 +449,26 @@ def print_circuitpython_download_stats():
                           "{}".format("-"*(long_col[2]))]))
 
     for row in by_lang_list:
-        output_handler(row_format.format(*row))
+        logger.info(row_format.format(*row))
     #for language in by_language:
-    #    output_handler("* {} - {}".format(language, by_language[language]))
-    output_handler()
+    #    logger.info("* {} - {}".format(language, by_language[language]))
+    logger.info("")
 
 def print_pr_overview(*insights):
     merged_prs = sum([len(x["merged_prs"]) for x in insights])
     authors = set().union(*[x["pr_merged_authors"] for x in insights])
     reviewers = set().union(*[x["pr_reviewers"] for x in insights])
 
-    output_handler("* {} pull requests merged".format(merged_prs))
-    output_handler("  * {} authors - {}".format(len(authors), ", ".join(authors)))
-    output_handler("  * {} reviewers - {}".format(len(reviewers), ", ".join(reviewers)))
+    logger.info("* {} pull requests merged".format(merged_prs))
+    logger.info("  * {} authors - {}".format(len(authors), ", ".join(authors)))
+    logger.info("  * {} reviewers - {}".format(len(reviewers), ", ".join(reviewers)))
 
 def print_issue_overview(*insights):
     closed_issues = sum([x["closed_issues"] for x in insights])
     issue_closers = set().union(*[x["issue_closers"] for x in insights])
     new_issues = sum([x["new_issues"] for x in insights])
     issue_authors = set().union(*[x["issue_authors"] for x in insights])
-    output_handler("* {} closed issues by {} people, {} opened by {} people"
+    logger.info("* {} closed issues by {} people, {} opened by {} people"
                    .format(closed_issues, len(issue_closers),
                    new_issues, len(issue_authors)))
 
@@ -489,17 +484,21 @@ def print_issue_overview(*insights):
             hacktober_changes += "* Removed Hacktoberfest label from {} issues.".format(
                 sum([x["hacktober_removed"] for x in insights])
             )
-        output_handler(hacktober_changes)
+        logger.info(hacktober_changes)
 
-def main(verbosity=1, output_filename=None, validator=None, error_depth=5):
+def main(verbose=1, output_file=None, validator=None, error_depth=5):
     validator_kwarg_list = {}
     startup_message = [
         "Running CircuitPython Library checks...",
         "Report Date: {}".format(datetime.datetime.now().strftime("%d %B %Y, %I:%M%p"))
     ]
 
-    if output_filename:
-        startup_message.append(" - Report output will be saved to: {}".format(output_filename))
+    verbosity = verbose
+    
+    if output_file:
+        fh = logging.FileHandler(output_file)
+        logger.addHandler(fh)
+        startup_message.append(" - Report output will be saved to: {}".format(output_file))
 
     validators = []
     validator_names = []
@@ -526,7 +525,7 @@ def main(verbosity=1, output_filename=None, validator=None, error_depth=5):
                     validator_names.append(func_name)
                 except KeyError:
                     #print(default_validators)
-                    output_handler("Error: '{0}' is not an available validator.\n" \
+                    logger.info("Error: '{0}' is not an available validator.\n" \
                                    "Available validators are: {1}".format(func.strip(),
                                    ", ".join([val[0] for val in default_validators])))
                     sys.exit()
@@ -544,35 +543,28 @@ def main(verbosity=1, output_filename=None, validator=None, error_depth=5):
 
     try:
         for message in startup_message:
-            output_handler(message)
-        output_handler()
+            logger.info(message)
+        logger.info("")
         #print(validators)
         run_library_checks(validators, bundle_submodules, latest_pylint,
                            validator_kwarg_list, error_depth)
     except:
-        if output_filename is not None:
-            exc_type, exc_val, exc_tb = sys.exc_info()
-            output_handler("Exception Occurred!", quiet=True)
-            output_handler(("-"*60), quiet=True)
-            output_handler("Traceback (most recent call last):", quiet=True)
-            tb = traceback.format_tb(exc_tb)
-            for line in tb:
-                output_handler(line, quiet=True)
-            output_handler(exc_val, quiet=True)
+        exc_type, exc_val, exc_tb = sys.exc_info()
+        logger.error("Exception Occurred!")
+        logger.error(("-"*60))
+        logger.error("Traceback (most recent call last):")
+        tb = traceback.format_tb(exc_tb)
+        for line in tb:
+            logger.error(line)
+        logger.error(exc_val)
 
         raise
-
-    finally:
-        if output_filename is not None:
-            with open(output_filename, 'w') as f:
-                for line in file_data:
-                    f.write(str(line) + "\n")
 
 if __name__ == "__main__":
     cli_args = cmd_line_parser.parse_args()
     main(
-        verbosity=cli_args.verbose,
-        output_filename=cli_args.output_file,
+        verbose=cli_args.verbose,
+        output_file=cli_args.output_file,
         validator=cli_args.validator,
         error_depth=cli_args.error_depth
     )

--- a/tests/integration/test_arduino_libraries.py
+++ b/tests/integration/test_arduino_libraries.py
@@ -15,3 +15,20 @@ def test_adafruit_libraries(monkeypatch):
     print(arduino_libraries.list_repos())
 
     arduino_libraries.main()
+
+def test_adafruit_libraries_output_file(monkeypatch, tmp_path, capsys):
+
+    def get_list_repos():
+        repos = []
+        repos.append(github_requests.get("/repos/adafruit/Adafruit_NeoPixel").json())
+        return repos
+
+    monkeypatch.setattr(arduino_libraries, "list_repos", get_list_repos)
+
+    tmp_output_file = tmp_path / "output_test.txt"
+
+    arduino_libraries.main(output_file=tmp_output_file)
+
+    captured = capsys.readouterr()
+
+    assert tmp_output_file.read_text() == captured.out

--- a/tests/integration/test_circuitpython_libraries.py
+++ b/tests/integration/test_circuitpython_libraries.py
@@ -14,3 +14,20 @@ def test_circuitpython_libraires(monkeypatch):
     monkeypatch.setattr(common_funcs, "list_repos", mock_list_repos)
 
     circuitpython_libraries.main(validator="all")
+
+def test_circuitpython_libraires_output_file(monkeypatch, tmp_path, capsys):
+    
+    def mock_list_repos(*args, **kwargs):
+        repos = []
+        repos.append(github_requests.get("/repos/adafruit/Adafruit_CircuitPython_TestRepo").json())
+        return repos
+    
+    monkeypatch.setattr(common_funcs, "list_repos", mock_list_repos)
+
+    tmp_output_file = tmp_path / "output_test.txt"
+
+    circuitpython_libraries.main(validator="all", output_file=tmp_output_file)
+
+    captured = capsys.readouterr()
+
+    assert tmp_output_file.read_text() == captured.out


### PR DESCRIPTION
@dherrada brought it to my attention that my last PR containing changes to allow/add tests, broke output file generation for reports.

The problem was the use of global scoped variables, that was broken by adding a `main` function.

This fix does what I should've done from the beginning, and utilizes `logging` to allow for multiple outputs.

Also added tests for output file generation.