### PR TITLE
Fixed merged pr check

### DIFF
--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -987,7 +987,11 @@ class library_validator():
                         insights["pr_authors"].add(pr_info["user"]["login"])
                     insights["active_prs"] += 1
                 else:
-                    if pr_info["merged"]:
+                    merged = datetime.datetime.strptime(
+                            issue["closed_at"],
+                            "%Y-%m-%dT%H:%M:%SZ"
+                            )
+                    if pr_info["merged"] and merged > since:
                         merged_info = ""
                         if show_closed_metric:
                             created = datetime.datetime.strptime(


### PR DESCRIPTION
Basically what was happening is that Adabot was searching for any PRs that had been updated in the last week, and not filtering out ones that were closed more than 7 days back.

Before: https://gist.github.com/dherrada/0721f6968d11178b6bd8a002ec6c42e4

Now: https://gist.github.com/dherrada/e7a68f86081657d536e1f741fa5bed8c