### PR TITLE
Update CircuitPython Report Order & Emergency Fix

### DIFF
--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -242,10 +242,7 @@ def run_library_checks(validators, kw_args, error_depth):
     )
     for pull_request in sorted_prs:
         logger.info("    * %s", pull_request)
-    print_issue_overview(lib_insights)
-    logger.info("* https://circuitpython.org/contributing")
-    logger.info("  * %s open issues", len(lib_insights["open_issues"]))
-    logger.info("  * %s good first issues", lib_insights["good_first_issues"])
+
     open_pr_days = [
         int(pr_sort_re.search(pull_request).group(1))
         for pull_request in lib_insights["open_prs"]
@@ -258,6 +255,14 @@ def run_library_checks(validators, kw_args, error_depth):
             max(open_pr_days),
             max((min(open_pr_days), 1)),  # ensure the minumum is '1'
         )
+
+    print_issue_overview(lib_insights)
+
+    logger.info("  * %s open issues", len(lib_insights["open_issues"]))
+    logger.info("  * %s good first issues", lib_insights["good_first_issues"])
+
+    logger.info("* https://circuitpython.org/contributing")
+
     logger.info("Library updates in the last seven days:")
     if len(new_libs) != 0:
         logger.info("**New Libraries**")

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -236,13 +236,9 @@ class LibraryValidator:
         if self._rtd_yaml_base is None:
             rtd_yml_dl_url = (
                 "https://raw.githubusercontent.com/adafruit/cookiecutter-adafruit-"
-                "circuitpython/main/%7B%25%20if%20cookiecutter.library_prefix"
-                "%20%25%7D%7B%7B%20cookiecutter.library_prefix%20%7C%20capitalize"
-                "%20%7D%7D_CircuitPython%7B%25%20else%20%25%7DCircuitPython_Org%7B"
-                "%25%20endif%20%25%7D_%7B%7B%20cookiecutter.library_name%7Creplace"
-                "(%22%20%22%2C%20%22_%22)%7D%7D/%7B%25%20if%20cookiecutter.sphinx"
-                "_docs%20in%20%5B'y'%2C%20'yes'%5D%20%25%7D.readthedocs.yml%7B%25"
-                "%20endif%20%25%7D"
+                "circuitpython/main/%7B%7B%20cookiecutter%20and%20'tmp_repo'%20%7D"
+                "%7D/%7B%25%20if%20cookiecutter.sphinx_docs%20in%20%5B'y'%2C%20'yes'"
+                "%5D%20%25%7D.readthedocs.yml%7B%25%20endif%20%25%7D"
             )
             rtd_yml = requests.get(rtd_yml_dl_url)
             if rtd_yml.ok:

--- a/adabot/update_cp_org_libraries.py
+++ b/adabot/update_cp_org_libraries.py
@@ -238,9 +238,9 @@ def main(
         # get the contributors and reviewers for the last week
         get_contribs, get_revs, get_merge_count = get_contributors(repo)
         if get_contribs:
-            contributors.add(get_contribs)
+            contributors.update(get_contribs)
         if get_revs:
-            reviewers.add(get_revs)
+            reviewers.update(get_revs)
         merged_pr_count_total += get_merge_count
 
         if repo_name in DO_NOT_VALIDATE:

--- a/tests/integration/test_update_cp_org_libraries.py
+++ b/tests/integration/test_update_cp_org_libraries.py
@@ -36,10 +36,23 @@ def mock_list_repos(*args, **kwargs):
     ]
 
 
+# pylint: disable=unused-argument
+def mock_get_contribs(*args):
+    """Function to monkeypatch `update_cp_org_libraries.get_contributors()` to ensure
+    proper testing of usage. Monkeypatched `list_repos` will likely not produce results.
+    """
+    contribs = ["test_user1", "test_user2"]
+    reviewers = ["test_reviewer1", "test_reviewer2"]
+    merged_pr_count = 4
+
+    return contribs, reviewers, merged_pr_count
+
+
 def test_update_cp_org_libraries(monkeypatch):
     """Test main function of 'circuitpyton_libraries.py', without writing an output file."""
 
     monkeypatch.setattr(common_funcs, "list_repos", mock_list_repos)
+    monkeypatch.setattr(update_cp_org_libraries, "get_contributors", mock_get_contribs)
 
     update_cp_org_libraries.main()
 
@@ -49,6 +62,7 @@ def test_update_cp_org_libraries_output_file(monkeypatch, tmp_path, capsys):
     """Test main funciton of 'update_cp_org_libraries.py', with writing an output file."""
 
     monkeypatch.setattr(common_funcs, "list_repos", mock_list_repos)
+    monkeypatch.setattr(update_cp_org_libraries, "get_contributors", mock_get_contribs)
 
     tmp_output_file = tmp_path / "output_test.txt"
 


### PR DESCRIPTION
Fixes #238

Updates report to match desired result:
```
### Libraries
* 8 pull requests merged
  * 6 authors - makermelissa, rdoursenaud, kattni, tannewt, Neradoc, lesamouraipourpre
  * 8 reviewers - makermelissa, dhalbert, tannewt, antonio-openroad, TheKitty, FoamyGuy, ladyada, kattni
  * Merged pull requests:
    * https://github.com/adafruit/Adafruit_CircuitPython_MIDI/pull/41 (Days open: 36)
    * https://github.com/adafruit/Adafruit_CircuitPython_BLE/pull/135 (Days open: 2)
    * https://github.com/adafruit/Adafruit_CircuitPython_BLE_File_Transfer/pull/13 (Days open: 1)
    * https://github.com/adafruit/Adafruit_CircuitPython_PortalBase/pull/49 (Days open: 1)
    * https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_SH1107/pull/9 (Days open: 1)
    * https://github.com/adafruit/Adafruit_CircuitPython_IS31FL3741/pull/2 (Days open: 1)
    * https://github.com/adafruit/Adafruit_CircuitPython_TLC59711/pull/19 (Days open: 1)
    * https://github.com/adafruit/Adafruit_CircuitPython_Bundle/pull/343 (Days open: 1)
  * 58 open pull requests (Oldest: 640, Newest: 1)
* 8 closed issues by 8 people, 3 opened by 3 people
  * 345 open issues
  * 4 good first issues
* https://circuitpython.org/contributing
Library updates in the last seven days:
```

### Emergency Fix
When changing `update_cp_org_libraries` to allow for testing, I used the incorrect method when changing a list variable to a set. Which broke the function (adafruit/circuitpython-org Actions run):
```
  cd adabot
  python3 -u -m adabot.update_cp_org_libraries -o $GITHUB_WORKSPACE/bin/adabot/libraries.v2.json
Running circuitpython.org/libraries updater...
Run Date: 22 September 2021, 09:22AM
 - Report output will be saved to: /home/runner/work/circuitpython-org/circuitpython-org/bin/adabot/libraries.v2.json
Error retrieving cookiecutter .readthedocs.yml
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/runner/work/circuitpython-org/circuitpython-org/adabot/adabot/update_cp_org_libraries.py", line 306, in <module>
    output_file=cmd_line_args.output_file,
  File "/home/runner/work/circuitpython-org/circuitpython-org/adabot/adabot/update_cp_org_libraries.py", line 241, in main
    contributors.add(get_contribs)
TypeError: unhashable type: 'list'
Error: Process completed with exit code 1.
```
This PR contains a fix for that. 

Additionally, this break highlighted that the integration test did not catch this error; the mocked `list_repos` uses `TestRepo` which will not provide consistent contributor information. So, the test now includes a mocked result for contributor info.

Lastly, in running tests before pushing this PR, changes in https://github.com/adafruit/cookiecutter-adafruit-circuitpython/pull/151 caused test failures. I updated the validator function with the new hardcoded link.