### PR TITLE
Tag Learn nightly, so that new artifacts are released

### DIFF
--- a/.github/workflows/learn_cron.yml
+++ b/.github/workflows/learn_cron.yml
@@ -1,0 +1,42 @@
+name: Tag Learning System Guides
+
+on:
+  schedule:
+    - cron: 0 5 * * *
+  push:
+
+jobs:
+  check-repo-owner:
+    # This job is so the entire workflow will end successfully and give some
+    # output to explain why it hasn't run on a non-Adafruit fork.
+    runs-on: ubuntu-latest
+    if: ${{ (github.repository_owner != 'adafruit') }}
+    steps:
+      - run: |
+          echo "This workflow is only intended to run in the adafruit fork of adabot"
+
+  update-learn:
+    runs-on: ubuntu-latest
+    # Only run the build if the access token has been configured.  THs will be
+    # the case on Adafruit's repository.  Its necessary to do this here, since
+    # 'schedule' events cannot (currently) be limited (they run on all forks'
+    # default branches).
+    #if: ${{ (github.repository_owner == 'adafruit') }}
+    steps:
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+    - uses: actions/checkout@v2
+      with:
+        repository: ${{ github.repository_owner }}/Adafruit_Learning_System_Guides
+        token: ${{ secrets.ADABOT_GITHUB_ACCESS_TOKEN }}
+    - name: Tag a release
+      env:
+        ADABOT_EMAIL: ${{ secrets.ADABOT_EMAIL }}
+      run: |
+        git config --global user.name adabot
+        git config --global user.email "$ADABOT_EMAIL"
+        TAG_NAME=`date +%Y%m%d`
+        git tag $TAG_NAME
+        git push origin $TAG_NAME


### PR DESCRIPTION
Typical workflow from within my fork (modified version so it would run in the fork):
https://github.com/jepler/adabot/runs/3883397046?check_suite_focus=true

Release created by it:
https://github.com/jepler/Adafruit_Learning_System_Guides/releases/tag/20211013