### PR TITLE
restore usual fork protections

### DIFF
--- a/.github/workflows/learn_cron.yml
+++ b/.github/workflows/learn_cron.yml
@@ -3,7 +3,6 @@ name: Tag Learning System Guides
 on:
   schedule:
     - cron: 0 5 * * *
-  push:
 
 jobs:
   check-repo-owner:
@@ -21,7 +20,7 @@ jobs:
     # the case on Adafruit's repository.  Its necessary to do this here, since
     # 'schedule' events cannot (currently) be limited (they run on all forks'
     # default branches).
-    #if: ${{ (github.repository_owner == 'adafruit') }}
+    if: ${{ (github.repository_owner == 'adafruit') }}
     steps:
     - name: Dump GitHub context
       env:


### PR DESCRIPTION
.. as well as release-on-push -- releasing learn on push to adabot doesn't make sense (but it was intended for my testing)