### PR TITLE
Added patch for rtd building

### DIFF
--- a/patches/0001-Fixed-readthedocs-build.patch
+++ b/patches/0001-Fixed-readthedocs-build.patch
@@ -1,0 +1,30 @@
+From 609b9a5243fbbc6e0f6014d4aeaa902a1d2ecfc9 Mon Sep 17 00:00:00 2001
+From: dherrada <dylan.herrada@adafruit.com>
+Date: Mon, 14 Feb 2022 15:35:02 -0500
+Subject: [PATCH] Fixed readthedocs build
+
+---
+ .readthedocs.yaml | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/.readthedocs.yaml b/.readthedocs.yaml
+index f8b2891..33c2a61 100644
+--- a/.readthedocs.yaml
++++ b/.readthedocs.yaml
+@@ -8,8 +8,12 @@
+ # Required
+ version: 2
+ 
++build:
++  os: ubuntu-20.04
++  tools:
++    python: "3"
++
+ python:
+-  version: "3.x"
+   install:
+     - requirements: docs/requirements.txt
+     - requirements: requirements.txt
+-- 
+2.25.1
+


### PR DESCRIPTION
Test PR:
https://github.com/adafruit/Adafruit_CircuitPython_BNO055/pull/93

Local test:
```
eherrada@eh:~/adafruit/temp/adabot$ python3 -m adabot.circuitpython_library_patches --dry-run -local -p 0001-Fixed-readthedocs-build.patch
.... Beginning Patch Updates ....
.... Working directory: /home/eherrada/adafruit/temp/adabot
.... Library directory: /home/eherrada/adafruit/temp/adabot/.libraries/
.... Patches directory: /home/eherrada/adafruit/temp/adabot/patches/
.... Deleting any previously cloned libraries
.... Running Patch Checks On 305 Repos ....
   . Skipping Adafruit_CircuitPython_BLE_File_Transfer: patch does not apply
   . Skipping Adafruit_CircuitPython_GFX: patch does not apply
   . Skipping Adafruit_CircuitPython_TestRepo: patch does not apply
   . Skipping Adafruit_CircuitPython_VL53L1X: patch does not apply
   . Skipping Adafruit_CircuitPython_OV5640: patch does not apply
   . Skipping Adafruit_CircuitPython_asyncio: patch does not apply
   . Skipping Adafruit_CircuitPython_24LC32: patch does not apply
   . Skipping Adafruit_CircuitPython_NeoPixel: patch does not apply
   . Skipping Adafruit_CircuitPython_HTTPServer: patch does not apply
   . Skipping Adafruit_CircuitPython_BLE_Creation: patch does not apply
   . Skipping Adafruit_CircuitPython_MONSTERM4SK: patch does not apply
   . Skipping Adafruit_CircuitPython_PCF8563: patch does not apply
   . Skipping Adafruit_CircuitPython_VS1053: patch does not apply
   . Skipping Adafruit_CircuitPython_AzureIoT: patch does not apply
   . Skipping Adafruit_CircuitPython_ADXL37x: patch does not apply
   . Skipping Adafruit_CircuitPython_Ticks: patch does not apply
   . Skipping Adafruit_CircuitPython_Bundle: patch does not apply
   . Skipping Adafruit_CircuitPython_Typing: patch does not apply
.... Patch Updates Completed ....
.... Patches Applied: 279
.... Patches Skipped: 18
.... Patches Failed: 8 
```