### PR TITLE
Changed examples dir check to be satisfied if repo name is at beginning of file or subdir containing file

### DIFF
--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -758,22 +758,27 @@ class LibraryValidator:
             else:
 
                 def __check_lib_name(
-                    repo_name, file_name
-                ):  # pylint: disable=unused-private-member
+                    repo_name,
+                    file_name,
+                ):
                     """Nested function to test example file names.
                     Allows examples to either match the repo name,
                     or have additional underscores separating the repo name.
                     """
                     file_names = set()
-                    file_names.add(file_name)
+                    file_names.add(file_name[9:])
 
-                    name_split = file_name.split("_")
+                    name_split = file_name[9:].split("_")
                     name_rebuilt = "".join(
                         (part for part in name_split if ".py" not in part)
                     )
 
                     if name_rebuilt:  # avoid adding things like 'simpletest.py' -> ''
                         file_names.add(name_rebuilt)
+
+                    if "/" in name_rebuilt:
+                        for i in name_rebuilt.split("/"):
+                            file_names.add(i)
 
                     return any(name.startswith(repo_name) for name in file_names)
 
@@ -785,7 +790,7 @@ class LibraryValidator:
                 for example in examples_list:
                     if example["name"].endswith(".py"):
                         check_lib_name = __check_lib_name(
-                            lib_name, example["name"].lower()
+                            lib_name, example["path"].lower()
                         )
                         if not check_lib_name:
                             all_have_name = False

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -776,10 +776,6 @@ class LibraryValidator:
                     if name_rebuilt:  # avoid adding things like 'simpletest.py' -> ''
                         file_names.add(name_rebuilt)
 
-                    if "/" in name_rebuilt:
-                        for i in name_rebuilt.split("/"):
-                            file_names.add(i)
-
                     return any(name.startswith(repo_name) for name in file_names)
 
                 lib_name_start = repo["name"].rfind("CircuitPython_") + 14

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -760,7 +760,7 @@ class LibraryValidator:
                 def __check_lib_name(
                     repo_name,
                     file_name,
-                ):
+                ):  # pylint: disable=unused-private-member
                     """Nested function to test example file names.
                     Allows examples to either match the repo name,
                     or have additional underscores separating the repo name.


### PR DESCRIPTION
Previously, any file in examples/ needed to have the library name at the beginning. However, some libraries ([such as BNO055](https://github.com/adafruit/Adafruit_CircuitPython_BNO055/tree/main/examples)) have more complicated demos that need their own subdirectory and probably shouldn't all start with the repo name.

This change makes this ok as long as the subdirectory has the library name in it.

Before change (in examples/ dir):
```
├── bno055_i2c-gpio_simpletest.py
├── bno055_simpletest.py
└── bno055_webgl_demo
    ├── server.py
```
Not ok

```
├── bno055_i2c-gpio_simpletest.py
├── bno055_simpletest.py
└── bno055_webgl_demo
    ├── bno055_server.py
```
Ok (but not always possible)

```
├── bno055_i2c-gpio_simpletest.py
├── bno055_simpletest.py
└── webgl_demo
    ├── bno055_server.py
```
Ok

After change:
```
├── bno055_i2c-gpio_simpletest.py
├── bno055_simpletest.py
└── bno055_webgl_demo
    ├── server.py
```
Ok

```
├── bno055_i2c-gpio_simpletest.py
├── bno055_simpletest.py
└── bno055_webgl_demo
    ├── bno055_server.py
```
Ok

```
├── bno055_i2c-gpio_simpletest.py
├── bno055_simpletest.py
└── webgl_demo
    ├── bno055_server.py
```
Not ok