### PR TITLE
Turn some tools into CLI tools

### DIFF
--- a/tools/ci_status.py
+++ b/tools/ci_status.py
@@ -18,8 +18,8 @@ from typing import Optional
 from github.Repository import Repository
 from github.Workflow import Workflow
 from github.GithubException import GithubException
-from tools.library_functions import StrPath
-from tools.iterate_libraries import (
+from library_functions import StrPath
+from iterate_libraries import (
     iter_remote_bundle_with_func,
     RemoteLibFunc_IterResult,
 )

--- a/tools/ci_status.py
+++ b/tools/ci_status.py
@@ -146,13 +146,31 @@ def save_build_statuses(
 
 if __name__ == "__main__":
 
-    parser = argparse.ArgumentParser(description="Check the CI status")
-    parser.add_argument("gh_token", metavar="GH_TOKEN", type=str)
-    parser.add_argument("--user", metavar="U", type=str, dest="user", default=None)
-    parser.add_argument(
-        "--workflow", metavar="W", type=str, dest="workflow", default="build.yml"
+    parser = argparse.ArgumentParser(
+        description="Check the CI status of the Bundle libraries"
     )
-    parser.add_argument("--debug", action="store_true")
+    parser.add_argument(
+        "gh_token", metavar="GH_TOKEN", type=str, help="GitHub token with proper scopes"
+    )
+    parser.add_argument(
+        "--user",
+        metavar="U",
+        type=str,
+        dest="user",
+        default=None,
+        help="User that triggered the workflow",
+    )
+    parser.add_argument(
+        "--workflow",
+        metavar="W",
+        type=str,
+        dest="workflow",
+        default="build.yml",
+        help="Workflow name",
+    )
+    parser.add_argument(
+        "--debug", action="store_true", help="Print debug text during execution"
+    )
 
     args = parser.parse_args()
 

--- a/tools/ci_status.py
+++ b/tools/ci_status.py
@@ -74,6 +74,9 @@ def check_build_status(
     if debug:
         print("Checking", lib_repo.name)
 
+    if lib_repo.archived:
+        return True
+
     try:
         result = run_gh_rest_check(lib_repo, user, workflow_filename) == "success"
         if debug and not result:

--- a/tools/ci_status.py
+++ b/tools/ci_status.py
@@ -158,7 +158,7 @@ if __name__ == "__main__":
         type=str,
         dest="user",
         default=None,
-        help="User that triggered the workflow",
+        help="Select a specific user that triggered the workflow",
     )
     parser.add_argument(
         "--workflow",
@@ -166,7 +166,7 @@ if __name__ == "__main__":
         type=str,
         dest="workflow",
         default="build.yml",
-        help="Workflow name",
+        help='Workflow name; default is "build.yml"',
     )
     parser.add_argument(
         "--debug", action="store_true", help="Print debug text during execution"

--- a/tools/ci_status.py
+++ b/tools/ci_status.py
@@ -15,6 +15,7 @@ contained within the Adafruit CircuitPython Bundle
 """
 
 from typing import Optional
+import argparse
 from github.Repository import Repository
 from github.Workflow import Workflow
 from github.GithubException import GithubException
@@ -141,3 +142,28 @@ def save_build_statuses(
         with open(failures_filepath, mode="w", encoding="utf-8") as outputfile:
             for build in bad_builds:
                 outputfile.write(build + "\n")
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description="Check the CI status")
+    parser.add_argument("gh_token", metavar="GH_TOKEN", type=str)
+    parser.add_argument("--user", metavar="U", type=str, dest="user", default=None)
+    parser.add_argument("--workflow", metavar="W", type=str, dest="workflow", default="build.yml")
+    parser.add_argument("--debug", action="store_true")
+
+    args = parser.parse_args()
+
+    results = check_build_statuses(args.gh_token, args.user, args.workflow, debug=args.debug)
+    fail_list = [repo_name.name for repo_name, repo_results in results if not repo_results[0]]
+
+    if fail_list:
+        print(f'Failures for CI workflow "{args.workflow}":')
+        for failure in fail_list:
+            print(failure)
+        return_code = 1
+    else:
+        print(f'No failures for CI workflow: {args.workflow}!')
+        return_code = 0
+
+    raise SystemExit(return_code)

--- a/tools/ci_status.py
+++ b/tools/ci_status.py
@@ -29,7 +29,7 @@ from iterate_libraries import (
 def run_gh_rest_check(
     lib_repo: Repository,
     user: Optional[str] = None,
-    branch: Optional[str] = "main",
+    branch: Optional[str] = None,
     workflow_filename: Optional[str] = "build.yml",
 ) -> str:
     """Uses ``PyGithub`` to check the CI status of a repository
@@ -38,7 +38,7 @@ def run_gh_rest_check(
     :param str|None user: The user that triggered the run; if `None` is
         provided, any user is acceptable
     :param str|None branch: The branch name to specifically check; if `None` is
-        provided, all branches are allowed; the default is ``"main"``
+        provided, all branches are allowed; this is the default
     :param str|None workflow_filename: The filename of the workflow; if `None` is
         provided, any workflow name is acceptable; the default is ``"build.yml"``
     :return: The requested runs conclusion
@@ -59,7 +59,7 @@ def run_gh_rest_check(
 def check_build_status(
     lib_repo: Repository,
     user: Optional[str] = None,
-    branch: Optional[str] = "main",
+    branch: Optional[str] = None,
     workflow_filename: Optional[str] = "build.yml",
     debug: bool = False,
 ) -> Optional[str]:
@@ -70,7 +70,7 @@ def check_build_status(
     :param str|None user: The user that triggered the run; if `None` is
         provided, any user is acceptable
     :param str|None branch: The branch name to specifically check; if `None` is
-        provided, all branches are allowed; the default is ``"main"``
+        provided, all branches are allowed; this is the default
     :param str|None workflow_filename: The filename of the workflow; if `None`
         is provided, any workflow name is acceptable; the defail is `"build.yml"`
     :param bool debug: Whether debug statements should be printed to the standard
@@ -120,7 +120,7 @@ def check_build_statuses(
     :param str|None user: The user that triggered the run; if `None` is
         provided, any user is acceptable
     :param str|None branch: The branch name to specifically check; if `None` is
-        provided, all branches are allowed; the default is ``"main"``
+        provided, all branches are allowed; this is the default
     :param str|None workflow_filename: The filename of the workflow; if `None` is
         provided, any workflow name is acceptable; the defail is `"build.yml"`
     :param bool debug: Whether debug statements should be printed to
@@ -179,7 +179,7 @@ if __name__ == "__main__":
         metavar="B",
         type=str,
         dest="branch",
-        default="main",
+        default=None,
         help='Branch name; default is "main"',
     )
     parser.add_argument(

--- a/tools/ci_status.py
+++ b/tools/ci_status.py
@@ -117,9 +117,9 @@ def check_build_statuses(
     :rtype: list
     """
 
-    args = (user, workflow_filename)
-    kwargs = {"debug": debug}
-    return iter_remote_bundle_with_func(gh_token, [(check_build_status, args, kwargs)])
+    return iter_remote_bundle_with_func(
+        gh_token, [(check_build_status, (user, workflow_filename), {"debug": debug})]
+    )
 
 
 def save_build_statuses(
@@ -149,21 +149,27 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Check the CI status")
     parser.add_argument("gh_token", metavar="GH_TOKEN", type=str)
     parser.add_argument("--user", metavar="U", type=str, dest="user", default=None)
-    parser.add_argument("--workflow", metavar="W", type=str, dest="workflow", default="build.yml")
+    parser.add_argument(
+        "--workflow", metavar="W", type=str, dest="workflow", default="build.yml"
+    )
     parser.add_argument("--debug", action="store_true")
 
     args = parser.parse_args()
 
-    results = check_build_statuses(args.gh_token, args.user, args.workflow, debug=args.debug)
-    fail_list = [repo_name.name for repo_name, repo_results in results if not repo_results[0]]
+    results = check_build_statuses(
+        args.gh_token, args.user, args.workflow, debug=args.debug
+    )
+    fail_list = [
+        repo_name.name for repo_name, repo_results in results if not repo_results[0]
+    ]
 
     if fail_list:
         print(f'Failures for CI workflow "{args.workflow}":')
         for failure in fail_list:
             print(failure)
-        return_code = 1
+        RETURN_CODE = 1
     else:
-        print(f'No failures for CI workflow: {args.workflow}!')
-        return_code = 0
+        print(f"No failures for CI workflow: {args.workflow}!")
+        RETURN_CODE = 0
 
-    raise SystemExit(return_code)
+    raise SystemExit(RETURN_CODE)

--- a/tools/docs_status.py
+++ b/tools/docs_status.py
@@ -95,9 +95,15 @@ def check_docs_statuses(
 
 if __name__ == "__main__":
 
-    parser = argparse.ArgumentParser(description="Check the RTD docs status")
-    parser.add_argument("gh_token", metavar="GH_TOKEN", type=str)
-    parser.add_argument("rtd_token", metavar="RTD_TOKEN", type=str)
+    parser = argparse.ArgumentParser(
+        description="Check the RTD docs build status of the Bundle libraries"
+    )
+    parser.add_argument(
+        "gh_token", metavar="GH_TOKEN", type=str, help="GitHub token with proper scopes"
+    )
+    parser.add_argument(
+        "rtd_token", metavar="RTD_TOKEN", type=str, help="ReadTheDocs token"
+    )
 
     args = parser.parse_args()
 

--- a/tools/docs_status.py
+++ b/tools/docs_status.py
@@ -19,7 +19,7 @@ import parse
 import requests
 from github.Repository import Repository
 from github.ContentFile import ContentFile
-from tools.iterate_libraries import (
+from iterate_libraries import (
     iter_remote_bundle_with_func,
     RemoteLibFunc_IterResult,
 )

--- a/tools/docs_status.py
+++ b/tools/docs_status.py
@@ -88,9 +88,9 @@ def check_docs_statuses(
     :rtype: list
     """
 
-    args = (rtd_token,)
-    kwargs = {}
-    return iter_remote_bundle_with_func(gh_token, [(check_docs_status, args, kwargs)])
+    return iter_remote_bundle_with_func(
+        gh_token, [(check_docs_status, (rtd_token,), {})]
+    )
 
 
 if __name__ == "__main__":
@@ -102,16 +102,19 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     results = check_docs_statuses(args.gh_token, args.rtd_token)
-    fail_list = [repo_name.name for repo_name, repo_results in results if repo_results[0] != True]
+    fail_list = [
+        repo_name.name
+        for repo_name, repo_results in results
+        if repo_results[0] == False  # pylint: disable=singleton-comparison
+    ]
 
     if fail_list:
-        print(f"Failures for RTD builds:")
+        print("Failures for RTD builds:")
         for failure in fail_list:
             print(failure)
-        return_code = 1
+        RETURN_CODE = 1
     else:
-        print(f'No failures for RTD builds!')
-        return_code = 0
+        print("No failures for RTD builds!")
+        RETURN_CODE = 0
 
-    raise SystemExit(return_code)
-
+    raise SystemExit(RETURN_CODE)

--- a/tools/docs_status.py
+++ b/tools/docs_status.py
@@ -15,6 +15,7 @@ in the Adafruit CircuitPython Bundle
 """
 
 from typing import Any, Optional
+import argparse
 import parse
 import requests
 from github.Repository import Repository
@@ -90,3 +91,27 @@ def check_docs_statuses(
     args = (rtd_token,)
     kwargs = {}
     return iter_remote_bundle_with_func(gh_token, [(check_docs_status, args, kwargs)])
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description="Check the RTD docs status")
+    parser.add_argument("gh_token", metavar="GH_TOKEN", type=str)
+    parser.add_argument("rtd_token", metavar="RTD_TOKEN", type=str)
+
+    args = parser.parse_args()
+
+    results = check_docs_statuses(args.gh_token, args.rtd_token)
+    fail_list = [repo_name.name for repo_name, repo_results in results if repo_results[0] != True]
+
+    if fail_list:
+        print(f"Failures for RTD builds:")
+        for failure in fail_list:
+            print(failure)
+        return_code = 1
+    else:
+        print(f'No failures for RTD builds!')
+        return_code = 0
+
+    raise SystemExit(return_code)
+

--- a/tools/git_functionality.py
+++ b/tools/git_functionality.py
@@ -19,7 +19,7 @@ from typing import Any
 import git
 import git.repo
 import git.index.base
-from tools.library_functions import StrPath
+from library_functions import StrPath
 
 
 def _get_repo_and_remote(

--- a/tools/iterate_libraries.py
+++ b/tools/iterate_libraries.py
@@ -23,7 +23,7 @@ import parse
 from github import Github
 from github.Repository import Repository
 from github.ContentFile import ContentFile
-from tools.library_functions import StrPath, LocalLibFunc, RemoteLibFunc
+from library_functions import StrPath, LocalLibFunc, RemoteLibFunc
 
 # Helpful type annotapython generic type aliastion definitions
 


### PR DESCRIPTION
Updates the tools for checking CI Actions and RTD docs build status into CLI tools.  This means they can be added to a CI workflow for building the bundle, or even just in their own regularly scheduled CI to check these things.  They would work like `pre-commit` hooks, in this way.