### PR TITLE
Add missing library typing_extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ requests-cache==0.5.2
 parse==1.19.0
 GitPython==3.1.27
 PyGithub==1.55
+typing-extensions


### PR DESCRIPTION
I think the CI has this but noticed I needed it when developing scripts in a virtual environment.