### PR TITLE
Update docs and CI checks

### DIFF
--- a/.github/workflows/reports_cron.yml
+++ b/.github/workflows/reports_cron.yml
@@ -29,6 +29,7 @@ jobs:
     env:
       ADABOT_GITHUB_USER: ${{ secrets.ADABOT_GITHUB_USER }}
       ADABOT_GITHUB_ACCESS_TOKEN: ${{ secrets.ADABOT_GITHUB_ACCESS_TOKEN }}
+      RTD_TOKEN: ${{ secrets.RTD_TOKEN }}
     steps:
       - name: Dump GitHub context
         env:

--- a/adabot/arduino_libraries.py
+++ b/adabot/arduino_libraries.py
@@ -11,7 +11,7 @@ import traceback
 
 import requests
 
-from adabot import github_requests as github
+from adabot import github_requests as gh_reqs
 
 logger = logging.getLogger(__name__)
 ch = logging.StreamHandler(stream=sys.stdout)
@@ -50,7 +50,7 @@ def list_repos():
     repository state.
     """
     repos = []
-    result = github.get(
+    result = gh_reqs.get(
         "/search/repositories",
         params={
             "q": (
@@ -70,7 +70,7 @@ def list_repos():
         )  # uncomment and comment below, to include all forks
 
         if result.links.get("next"):
-            result = github.get(result.links["next"]["url"])
+            result = gh_reqs.get(result.links["next"]["url"])
         else:
             break
 
@@ -124,7 +124,7 @@ def validate_library_properties(repo):
             lib_version = line[len("version=") :]
             break
 
-    get_latest_release = github.get(
+    get_latest_release = gh_reqs.get(
         "/repos/adafruit/" + repo["name"] + "/releases/latest"
     )
     if get_latest_release.ok:
@@ -151,7 +151,7 @@ def validate_release_state(repo):
     if not is_arduino_library(repo):
         return None
 
-    compare_tags = github.get(
+    compare_tags = gh_reqs.get(
         "/repos/" + repo["full_name"] + "/compare/master..." + repo["tag_name"]
     )
     if not compare_tags.ok:
@@ -187,7 +187,7 @@ def validate_actions(repo):
 
 def validate_example(repo):
     """Validate if a repo has any files in examples directory"""
-    repo_has_ino = github.get("/repos/adafruit/" + repo["name"] + "/contents/examples")
+    repo_has_ino = gh_reqs.get("/repos/adafruit/" + repo["name"] + "/contents/examples")
     return repo_has_ino.ok and len(repo_has_ino.json())
 
 

--- a/adabot/circuitpython_bundle.py
+++ b/adabot/circuitpython_bundle.py
@@ -18,7 +18,7 @@ import redis as redis_py
 import sh
 from sh.contrib import git
 
-from adabot import github_requests as github
+from adabot import github_requests as gh_reqs
 from adabot.lib import common_funcs
 
 REDIS = None
@@ -284,7 +284,7 @@ def get_contributors(repo, commit_range):
         author = REDIS.get("github_username:" + author_email)
         committer = REDIS.get("github_username:" + committer_email)
         if not author or not committer:
-            github_commit_info = github.get("/repos/" + repo + "/commits/" + sha)
+            github_commit_info = gh_reqs.get("/repos/" + repo + "/commits/" + sha)
             github_commit_info = github_commit_info.json()
             if github_commit_info["author"]:
                 author = github_commit_info["author"]["login"]
@@ -332,7 +332,7 @@ def new_release(bundle, bundle_path):
     working_directory = os.path.abspath(os.getcwd())
     os.chdir(bundle_path)
     print(bundle)
-    current_release = github.get("/repos/adafruit/{}/releases/latest".format(bundle))
+    current_release = gh_reqs.get("/repos/adafruit/{}/releases/latest".format(bundle))
     last_tag = current_release.json()["tag_name"]
     contributors = get_contributors("adafruit/" + bundle, last_tag + "..")
     added_submodules = []
@@ -430,7 +430,7 @@ def new_release(bundle, bundle_path):
 
     print("Releasing {}".format(release["tag_name"]))
     print(release["body"])
-    response = github.post("/repos/adafruit/" + bundle + "/releases", json=release)
+    response = gh_reqs.post("/repos/adafruit/" + bundle + "/releases", json=release)
     if not response.ok:
         print("Failed to create release")
         print(release)

--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -13,7 +13,7 @@ import re
 import sys
 import traceback
 
-from adabot import github_requests as github
+from adabot import github_requests as gh_reqs
 from adabot import pypi_requests as pypi
 from adabot.lib import circuitpython_library_validators as cirpy_lib_vals
 from adabot.lib import common_funcs
@@ -307,7 +307,7 @@ def print_circuitpython_dl_stats():
     #       enable this.
 
     try:
-        response = github.get("/repos/adafruit/circuitpython/releases")
+        response = gh_reqs.get("/repos/adafruit/circuitpython/releases")
     except (ValueError, RuntimeError):
         logger.info("Core CircuitPython GitHub download statistics request failed.")
         return

--- a/adabot/circuitpython_library_download_stats.py
+++ b/adabot/circuitpython_library_download_stats.py
@@ -13,7 +13,7 @@ import traceback
 import operator
 import requests
 
-from adabot import github_requests as github
+from adabot import github_requests as gh_reqs
 from adabot.lib import common_funcs
 
 # Setup ArgumentParser
@@ -107,7 +107,7 @@ def get_bundle_stats(bundle):
     that tag name(s) will be the date (YYYYMMDD).
     """
     stats_dict = {}
-    bundle_stats = github.get("/repos/adafruit/" + bundle + "/releases")
+    bundle_stats = gh_reqs.get("/repos/adafruit/" + bundle + "/releases")
     if not bundle_stats.ok:
         return {"Failed to retrieve bundle stats": bundle_stats.text}
     start_date = datetime.date.today()

--- a/adabot/lib/assign_hacktober_label.py
+++ b/adabot/lib/assign_hacktober_label.py
@@ -11,7 +11,7 @@ import argparse
 import datetime
 import requests
 
-from adabot import github_requests as github
+from adabot import github_requests as gh_reqs
 from adabot.lib import common_funcs
 
 cli_args = argparse.ArgumentParser(description="Hacktoberfest Label Assigner")
@@ -61,7 +61,7 @@ def get_open_issues(repo):
     params = {
         "state": "open",
     }
-    response = github.get("/repos/" + repo["full_name"] + "/issues", params=params)
+    response = gh_reqs.get("/repos/" + repo["full_name"] + "/issues", params=params)
     if not response.ok:
         print(f"Failed to retrieve issues for '{repo['name']}'")
         return False
@@ -84,7 +84,7 @@ def ensure_hacktober_label_exists(repo, dry_run=False):
     """Checks if the 'Hacktoberfest' label exists on the repo.
     If not, creates the label.
     """
-    response = github.get(f"/repos/{repo['full_name']}/labels")
+    response = gh_reqs.get(f"/repos/{repo['full_name']}/labels")
     if not response.ok:
         print(f"Failed to retrieve labels for '{repo['name']}'")
         return False
@@ -99,7 +99,7 @@ def ensure_hacktober_label_exists(repo, dry_run=False):
             "description": "DigitalOcean's Hacktoberfest",
         }
         if not dry_run:
-            result = github.post(f"/repos/{repo['full_name']}/labels", json=params)
+            result = gh_reqs.post(f"/repos/{repo['full_name']}/labels", json=params)
             if not result.status_code == 201:
                 print(f"Failed to create new Hacktoberfest label for: {repo['name']}")
                 return False
@@ -139,7 +139,7 @@ def assign_hacktoberfest(repo, issues=None, remove_labels=False, dry_run=False):
             label_names.append("Hacktoberfest")
             params = {"labels": label_names}
             if not dry_run:
-                result = github.patch(
+                result = gh_reqs.patch(
                     f"/repos/{repo['full_name']}/issues/{str(issue['number'])}",
                     json=params,
                 )

--- a/adabot/lib/blinka_funcs.py
+++ b/adabot/lib/blinka_funcs.py
@@ -4,7 +4,7 @@
 
 """Common functions used with Adabot & Blinka interactions."""
 
-from adabot import github_requests as github
+from adabot import github_requests as gh_reqs
 
 
 def board_count():
@@ -13,7 +13,7 @@ def board_count():
     """
     count = 0
     cirpy_org_url = "/repos/adafruit/circuitpython-org/contents/_blinka"
-    response = github.get(cirpy_org_url)
+    response = gh_reqs.get(cirpy_org_url)
     if response.ok:
         response_json = response.json()
         count = len(response_json)

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -10,9 +10,11 @@ errors, across the entire CirtuitPython library ecosystem."""
 import datetime
 from io import StringIO
 import json
+import os
 import logging
 import pathlib
 import re
+import time
 from tempfile import TemporaryDirectory
 
 from packaging.version import parse as pkg_version_parse
@@ -26,11 +28,14 @@ import sh
 from sh.contrib import git
 
 import yaml
+import parse
 
+import github as pygithub
 from adabot import github_requests as gh_reqs
 from adabot.lib import common_funcs
 from adabot.lib import assign_hacktober_label as hacktober
 
+GH_INTERFACE = pygithub.Github(os.environ["ADABOT_GITHUB_ACCESS_TOKEN"])
 
 class CapturedJsonReporter(JSONReporter):
     """Helper class to stringify PyLint JSON reports."""
@@ -106,18 +111,10 @@ ERROR_UNABLE_PULL_REPO_DETAILS = "Unable to pull repo details"
 ERRRO_UNABLE_PULL_REPO_EXAMPLES = "Unable to retrieve examples folder contents"
 ERROR_WIKI_DISABLED = "Wiki should be disabled"
 ERROR_ONLY_ALLOW_MERGES = "Only allow merges, disallow rebase and squash"
-ERROR_RTD_SUBPROJECT_FAILED = "Failed to list CircuitPython subprojects on ReadTheDocs"
 ERROR_RTD_SUBPROJECT_MISSING = "ReadTheDocs missing as a subproject on CircuitPython"
 ERROR_RTD_ADABOT_MISSING = "ReadTheDocs project missing adabot as owner"
-ERROR_RTD_VALID_VERSIONS_FAILED = "Failed to fetch ReadTheDocs valid versions"
-ERROR_RTD_FAILED_TO_LOAD_BUILDS = "Unable to load builds webpage"
-ERROR_RTD_FAILED_TO_LOAD_BUILD_INFO = "Failed to load build info"
+ERROR_RTD_FAILED_TO_LOAD_BUILD_STATUS = "Failed to load build status"
 ERROR_RTD_OUTPUT_HAS_WARNINGS = "ReadTheDocs latest build has warnings and/or errors"
-ERROR_RTD_AUTODOC_FAILED = (
-    "Autodoc failed on ReadTheDocs. (Likely need to automock an import.)"
-)
-ERROR_RTD_SPHINX_FAILED = "Sphinx missing files"
-ERROR_GITHUB_RELEASE_FAILED = "Failed to fetch latest release from GitHub"
 ERROR_GITHUB_NO_RELEASE = "Library repository has no releases"
 ERROR_GITHUB_COMMITS_SINCE_LAST_RELEASE_GTM = (
     "Library has new commits since last release over a month ago"
@@ -314,24 +311,20 @@ class LibraryValidator:
         has passed.
         Just returns a message stating that the most recent run failed.
         """
+
         if not (
             repo["owner"]["login"] == "adafruit"
             and repo["name"].startswith("Adafruit_CircuitPython")
         ):
             return []
 
-        actions_params = {"branch": repo["default_branch"]}
-        response = github.get(
-            "/repos/" + repo["full_name"] + "/actions/runs", params=actions_params
-        )
-
-        if not response.ok:
+        try:
+            repo_obj = GH_INTERFACE.get_repo("Adafruit/" + repo["full_name"])
+            workflow = repo_obj.get_workflow("build.yml")
+            workflow_runs = workflow.get_runs(branch = "main")
+            return [] if workflow_runs[0].conclusion else [ERROR_GITHUB_FAILING_ACTIONS]
+        except pygithub.GithubException:
             return [ERROR_UNABLE_PULL_REPO_DETAILS]
-
-        workflow_runs = response.json()["workflow_runs"]
-        if workflow_runs and workflow_runs[0]["conclusion"] == "failure":
-            return [ERROR_GITHUB_FAILING_ACTIONS]
-        return []
 
     # pylint: disable=too-many-locals,too-many-return-statements,too-many-branches
     def validate_release_state(self, repo):
@@ -838,7 +831,8 @@ class LibraryValidator:
         return errors
 
     def validate_readthedocs(self, repo):
-        """Method to check the health of `repo`'s ReadTheDocs."""
+        """Method to check the status of `repo`'s ReadTheDocs."""
+
         if not (
             repo["owner"]["login"] == "adafruit"
             and repo["name"].startswith("Adafruit_CircuitPython")
@@ -846,18 +840,6 @@ class LibraryValidator:
             return []
         if repo["name"] in BUNDLE_IGNORE_LIST:
             return []
-        if not self.rtd_subprojects:
-            rtd_response = requests.get(
-                "https://readthedocs.org/api/v2/project/74557/subprojects/", timeout=15
-            )
-            if not rtd_response.ok:
-                return [ERROR_RTD_SUBPROJECT_FAILED]
-            self.rtd_subprojects = {}
-            for subproject in rtd_response.json()["subprojects"]:
-                self.rtd_subprojects[
-                    common_funcs.sanitize_url(subproject["repo"])
-                ] = subproject
-
         repo_url = common_funcs.sanitize_url(repo["clone_url"])
         if repo_url not in self.rtd_subprojects:
             return [ERROR_RTD_SUBPROJECT_MISSING]
@@ -867,82 +849,40 @@ class LibraryValidator:
 
         if 105398 not in subproject["users"]:
             errors.append(ERROR_RTD_ADABOT_MISSING)
+        
+        
+        # Get the README file contents
+        try:
+            lib_repo = GH_INTERFACE.get_repo("Adafruit/" + repo["full_name"])
+        except pygithub.GithubException:
+            errors.append(ERROR_RTD_FAILED_TO_LOAD_BUILD_STATUS)
+            return errors
+        content_file = lib_repo.get_contents("README.rst")
+        readme_text = content_file.decoded_content.decode("utf-8")
 
-        valid_versions = requests.get(
-            "https://readthedocs.org/api/v2/project/{}/active_versions/".format(
-                subproject["id"]
-            ),
-            timeout=15,
+        # Parse for the ReadTheDocs slug
+        search_results: parse.Result = parse.search(
+            "https://readthedocs.org/projects/{slug:S}/badge", readme_text
         )
-        if not valid_versions.ok:
-            errors.append(ERROR_RTD_VALID_VERSIONS_FAILED)
-        else:
-            valid_versions = valid_versions.json()
-            latest_release = github.get(
-                "/repos/{}/releases/latest".format(repo["full_name"])
-            )
-            if not latest_release.ok:
-                errors.append(ERROR_GITHUB_RELEASE_FAILED)
-            # disabling this for now, since it is ignored and always fails
-            # else:
-            #    if (
-            #       latest_release.json()["tag_name"] not in
-            #       [tag["verbose_name"] for tag in valid_versions["versions"]]
-            #   ):
-            #        errors.append(ERROR_RTD_MISSING_LATEST_RELEASE)
+        rtd_slug: str = search_results.named["slug"]
+        rtd_slug = rtd_slug.replace("_", "-", -1)
 
-        # There is no API which gives access to a list of builds for a project so we parse the html
-        # webpage.
-        builds_webpage = requests.get(
-            "https://readthedocs.org/projects/{}/builds/".format(subproject["slug"]),
-            timeout=15,
-        )
-        # pylint: disable=too-many-nested-blocks
-        # TODO: look into reducing the number of nested blocks.
-        if not builds_webpage.ok:
-            errors.append(ERROR_RTD_FAILED_TO_LOAD_BUILDS)
-        else:
-            for line in builds_webpage.text.split("\n"):
-                if '<div id="build-' in line:
-                    build_id = line.split('"')[1][len("build-") :]
-                # We only validate the most recent, latest build. So, break when the first "version
-                # latest" found. Its in the page after the build id.
-                if "version latest" in line:
-                    break
-            build_info = requests.get(
-                "https://readthedocs.org/api/v2/build/{}/".format(build_id), timeout=15
-            )
-            if not build_info.ok:
-                errors.append(ERROR_RTD_FAILED_TO_LOAD_BUILD_INFO)
-            else:
-                build_info = build_info.json()
-                output_ok = True
-                autodoc_ok = True
-                sphinx_ok = True
-                for command in build_info["commands"]:
-                    if command["command"].endswith("_build/html"):
-                        for line in command["output"].split("\n"):
-                            if "... " in line:
-                                _, line = line.split("... ")
-                            if "WARNING" in line or "ERROR" in line:
-                                if not line.startswith(("WARNING", "ERROR")):
-                                    line = line.split(" ", 1)[1]
-                                if not line.startswith(RTD_IGNORE_NOTICES):
-                                    output_ok = False
-                            elif line.startswith("ImportError"):
-                                autodoc_ok = False
-                            elif line.startswith("sphinx.errors") or line.startswith(
-                                "SphinxError"
-                            ):
-                                sphinx_ok = False
-                        break
-                if not output_ok:
-                    errors.append(ERROR_RTD_OUTPUT_HAS_WARNINGS)
-                if not autodoc_ok:
-                    errors.append(ERROR_RTD_AUTODOC_FAILED)
-                if not sphinx_ok:
-                    errors.append(ERROR_RTD_SPHINX_FAILED)
+        # GET the latest documentation build runs
+        url = f"https://readthedocs.org/api/v3/projects/{rtd_slug}/builds/"
+        rtd_token = os.environ["RTD_TOKEN"]
+        headers = {"Authorization": f"token {rtd_token}"}
+        response = requests.get(url, headers=headers)
+        json_response = response.json()
 
+        # Return the results of the latest run
+        doc_build_results = json_response.get("results")
+        if doc_build_results is None:
+            errors.append(ERROR_RTD_FAILED_TO_LOAD_BUILD_STATUS)
+            return errors
+        result = doc_build_results[0].get("success")
+        time.sleep(3)
+        if not result:
+            errors.append(ERROR_RTD_OUTPUT_HAS_WARNINGS)
         return errors
 
     def validate_core_driver_page(self, repo):
@@ -1190,7 +1130,7 @@ class LibraryValidator:
         has_all_labels = True
         for label, info in STD_REPO_LABELS.items():
             if not label in repo_labels:
-                response = github.post(
+                response = gh_reqs.post(
                     "/repos/" + repo["full_name"] + "/labels",
                     json={"name": label, "color": info["color"]},
                 )

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -37,6 +37,7 @@ from adabot.lib import assign_hacktober_label as hacktober
 
 GH_INTERFACE = pygithub.Github(os.environ["ADABOT_GITHUB_ACCESS_TOKEN"])
 
+
 class CapturedJsonReporter(JSONReporter):
     """Helper class to stringify PyLint JSON reports."""
 
@@ -321,7 +322,7 @@ class LibraryValidator:
         try:
             repo_obj = GH_INTERFACE.get_repo("Adafruit/" + repo["full_name"])
             workflow = repo_obj.get_workflow("build.yml")
-            workflow_runs = workflow.get_runs(branch = "main")
+            workflow_runs = workflow.get_runs(branch="main")
             return [] if workflow_runs[0].conclusion else [ERROR_GITHUB_FAILING_ACTIONS]
         except pygithub.GithubException:
             return [ERROR_UNABLE_PULL_REPO_DETAILS]
@@ -849,8 +850,7 @@ class LibraryValidator:
 
         if 105398 not in subproject["users"]:
             errors.append(ERROR_RTD_ADABOT_MISSING)
-        
-        
+
         # Get the README file contents
         try:
             lib_repo = GH_INTERFACE.get_repo("Adafruit/" + repo["full_name"])

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -115,6 +115,7 @@ ERROR_ONLY_ALLOW_MERGES = "Only allow merges, disallow rebase and squash"
 ERROR_RTD_SUBPROJECT_MISSING = "ReadTheDocs missing as a subproject on CircuitPython"
 ERROR_RTD_ADABOT_MISSING = "ReadTheDocs project missing adabot as owner"
 ERROR_RTD_FAILED_TO_LOAD_BUILD_STATUS = "Failed to load build status"
+ERROR_RTD_SUBPROJECT_FAILED = "Failed to list CircuitPython subprojects on ReadTheDocs"
 ERROR_RTD_OUTPUT_HAS_WARNINGS = "ReadTheDocs latest build has warnings and/or errors"
 ERROR_GITHUB_NO_RELEASE = "Library repository has no releases"
 ERROR_GITHUB_COMMITS_SINCE_LAST_RELEASE_GTM = (
@@ -841,6 +842,17 @@ class LibraryValidator:
             return []
         if repo["name"] in BUNDLE_IGNORE_LIST:
             return []
+        if not self.rtd_subprojects:
+            rtd_response = requests.get(
+                "https://readthedocs.org/api/v2/project/74557/subprojects/", timeout=15
+            )
+            if not rtd_response.ok:
+                return [ERROR_RTD_SUBPROJECT_FAILED]
+            self.rtd_subprojects = {}
+            for subproject in rtd_response.json()["subprojects"]:
+                self.rtd_subprojects[
+                    common_funcs.sanitize_url(subproject["repo"])
+                ] = subproject
         repo_url = common_funcs.sanitize_url(repo["clone_url"])
         if repo_url not in self.rtd_subprojects:
             return [ERROR_RTD_SUBPROJECT_MISSING]

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -579,7 +579,7 @@ class LibraryValidator:
             errors.append(ERROR_BLACK_VERSION)
 
         reuse_repo = "repo: https://github.com/fsfe/reuse-tool"
-        reuse_version = "rev: v0.12.1"
+        reuse_version = "rev: v0.14.0"
 
         if reuse_repo not in text or reuse_version not in text:
             errors.append(ERROR_REUSE_VERSION)

--- a/adabot/lib/common_funcs.py
+++ b/adabot/lib/common_funcs.py
@@ -12,7 +12,7 @@ import datetime
 import os
 import re
 import requests
-from adabot import github_requests as github
+from adabot import github_requests as gh_reqs
 from adabot import pypi_requests as pypi
 
 CORE_REPO_URL = "/repos/adafruit/circuitpython"
@@ -165,7 +165,7 @@ def list_repos(*, include_repos=None):
                                       are included.
     """
     repos = []
-    result = github.get(
+    result = gh_reqs.get(
         "/search/repositories",
         params={
             "q": "Adafruit_CircuitPython user:adafruit archived:false fork:true",
@@ -190,21 +190,21 @@ def list_repos(*, include_repos=None):
         )
 
         if result.links.get("next"):
-            result = github.get(result.links["next"]["url"])
+            result = gh_reqs.get(result.links["next"]["url"])
         else:
             break
 
     repo_names = [repo["name"] for repo in repos]
 
     if "circuitpython" not in repo_names:
-        core = github.get(CORE_REPO_URL)
+        core = gh_reqs.get(CORE_REPO_URL)
         if core.ok:
             repos.append(core.json())
 
     if include_repos:
         for repo in include_repos:
             if repo not in repo_names:
-                add_repo = github.get("/repos/adafruit/" + repo)
+                add_repo = gh_reqs.get("/repos/adafruit/" + repo)
                 if add_repo.ok:
                     repos.append(add_repo.json())
                 else:
@@ -247,7 +247,7 @@ def is_new_or_updated(repo):
     today_minus_seven = datetime.datetime.today() - datetime.timedelta(days=7)
 
     # first, check the latest release to see if within the last 7 days
-    result = github.get("/repos/adafruit/" + repo["name"] + "/releases/latest")
+    result = gh_reqs.get("/repos/adafruit/" + repo["name"] + "/releases/latest")
     if not result.ok:
         return None
     release_info = result.json()
@@ -262,7 +262,7 @@ def is_new_or_updated(repo):
 
     # we have a release within the last 7 days. now check if its a newly
     # released library within the last week, or if its just an update
-    result = github.get("/repos/adafruit/" + repo["name"] + "/releases")
+    result = gh_reqs.get("/repos/adafruit/" + repo["name"] + "/releases")
     if not result.ok:
         return None
 
@@ -291,7 +291,7 @@ def whois_github_user():
     if "GITHUB_ACTOR" in os.environ:
         user = os.environ["GITHUB_ACTOR"]
     else:
-        user = github.get("/user").json()["login"]
+        user = gh_reqs.get("/user").json()["login"]
 
     return user
 

--- a/adabot/update_cp_org_libraries.py
+++ b/adabot/update_cp_org_libraries.py
@@ -16,7 +16,7 @@ import sys
 
 from adabot.lib import common_funcs
 from adabot.lib import circuitpython_library_validators as cpy_vals
-from adabot import github_requests as github
+from adabot import github_requests as gh_reqs
 from adabot import pypi_requests as pypi
 
 logger = logging.getLogger(__name__)
@@ -65,7 +65,7 @@ def get_open_issues_and_prs(repo):
     open_issues = []
     open_pull_requests = []
     params = {"state": "open"}
-    result = github.get("/repos/adafruit/" + repo["name"] + "/issues", params=params)
+    result = gh_reqs.get("/repos/adafruit/" + repo["name"] + "/issues", params=params)
     if not result.ok:
         return [], []
 
@@ -101,7 +101,7 @@ def get_contributors(repo):
     reviewers = []
     merged_pr_count = 0
     params = {"state": "closed", "sort": "updated", "direction": "desc"}
-    result = github.get("/repos/adafruit/" + repo["name"] + "/pulls", params=params)
+    result = gh_reqs.get("/repos/adafruit/" + repo["name"] + "/pulls", params=params)
     if result.ok:
         today_minus_seven = datetime.datetime.today() - datetime.timedelta(days=7)
         pull_requests = result.json()
@@ -121,12 +121,12 @@ def get_contributors(repo):
             merged_pr_count += 1
 
             # get reviewers (merged_by, and any others)
-            single_pr = github.get(pull_request["url"])
+            single_pr = gh_reqs.get(pull_request["url"])
             if not single_pr.ok:
                 continue
             pr_info = single_pr.json()
             reviewers.append(pr_info["merged_by"]["login"])
-            pr_reviews = github.get(str(pr_info["url"]) + "/reviews")
+            pr_reviews = gh_reqs.get(str(pr_info["url"]) + "/reviews")
             if not pr_reviews.ok:
                 continue
             for review in pr_reviews.json():
@@ -158,7 +158,7 @@ def main(
         logger.addHandler(file_handler)
 
     if cache_http:
-        cpy_vals.github.setup_cache(cache_ttl)
+        cpy_vals.gh_reqs.setup_cache(cache_ttl)
 
     repos = common_funcs.list_repos(
         include_repos=(

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ requests-cache==0.5.2
 parse==1.19.0
 GitPython==3.1.27
 PyGithub==1.55
-typing-extensions
+typing-extensions~=4.0

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,1 @@
+# Tools directory. UPDATE THIS README.


### PR DESCRIPTION
Uses a version of the code I made for `tools/` to better check the RTD docs build status and GitHub Actions CI status.  Hooks into adabot the same way as all the other checks so circuitpython.org gets the issues populated.

Also fixes the companion CLI tools that do the same.