### PR TITLE
Pin the pylint version to what the libraries are using

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 
 black==22.3.0
 packaging==20.3
-pylint
+pylint==2.11.1
 pytest
 pyyaml==5.4.1
 redis==2.10.6


### PR DESCRIPTION
Based on what I'm seeing here, I think a mismatch between the version of `pylint` being used within adabout on the libraries, and what the version the `pre-commit` hooks are running is likely causing some false failures to show up on circuitpython.org.  This changes pins the dependency to the same version that the hooks use, which means they should align more closely (hopefully 1:1!)