### PR TITLE
Fix linting check

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 
 black==22.3.0
 packaging==20.3
-pylint
+pylint==2.11.1
 pytest
 pyyaml==5.4.1
 redis==2.10.6


### PR DESCRIPTION
Now uses `subprocess` to check the return code, and also references the disables in the `.pre-commit-config.yaml` file so it'll stop flagging things disabled there.