### PR TITLE
Convery pylint check to CI check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ _build
 .bundles/*
 *.pyc
 .env
+.venv
 env.sh
 *.swp
 .libraries/*

--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -95,7 +95,7 @@ def run_library_checks(validators, kw_args, error_depth):
     pylint_info = pypi.get("/pypi/pylint/json")
     if pylint_info and pylint_info.ok:
         latest_pylint = pylint_info.json()["info"]["version"]
-    #logger.info("Latest pylint is: %s", latest_pylint)
+    # logger.info("Latest pylint is: %s", latest_pylint)
 
     repos = common_funcs.list_repos(
         include_repos=tuple(blinka_repos)

--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -95,7 +95,7 @@ def run_library_checks(validators, kw_args, error_depth):
     pylint_info = pypi.get("/pypi/pylint/json")
     if pylint_info and pylint_info.ok:
         latest_pylint = pylint_info.json()["info"]["version"]
-    logger.info("Latest pylint is: %s", latest_pylint)
+    #logger.info("Latest pylint is: %s", latest_pylint)
 
     repos = common_funcs.list_repos(
         include_repos=tuple(blinka_repos)

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -10,18 +10,12 @@ errors, across the entire CirtuitPython library ecosystem."""
 import datetime
 import os
 import logging
-import pathlib
 import re
-import subprocess
 import time
-from tempfile import TemporaryDirectory
 
 from packaging.version import parse as pkg_version_parse
 
 import requests
-
-import sh
-from sh.contrib import git
 
 import yaml
 import parse
@@ -1180,7 +1174,6 @@ class LibraryValidator:
 
                     logging.info("Sleeping %s seconds", reset_diff.seconds)
                     time.sleep(reset_diff.seconds + 1)
-
 
     def validate_default_branch(self, repo):
         """Makes sure that the default branch is main"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 
 black==22.3.0
 packaging==20.3
-pylint
+pylint==2.11.1
 pytest
 pyyaml==5.4.1
 redis==2.10.6


### PR DESCRIPTION
Using `pylint` locally is pretty complicated due to all the disables and knobs that are turned for each library, so this change uses each library's own build CI check to confirm `pylint` (and other things) was successful.  Fixes #285.

Also:
- Silences announcing the latest version of `pylint`
- Pins `pylint` in repo to the version used be pre-commit for safety
- Adds `.venv` to `.gitignore`

Tested successfully locally.