### PR TITLE
Allow for using pytest with/without tokens

### DIFF
--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -178,6 +178,7 @@ STD_REPO_LABELS = {
 
 _TOKEN_FUNCTIONS = []
 
+
 def uses_token(func):
     """Decorator for recording functions that use tokens"""
     _TOKEN_FUNCTIONS.append(func.__name__)

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -176,11 +176,11 @@ STD_REPO_LABELS = {
     "good first issue": {"color": "7057ff"},
 }
 
-TOKEN_FUNCTIONS = []
+_TOKEN_FUNCTIONS = []
 
 def uses_token(func):
     """Decorator for recording functions that use tokens"""
-    TOKEN_FUNCTIONS.append(func.__name__)
+    _TOKEN_FUNCTIONS.append(func.__name__)
     return func
 
 
@@ -227,6 +227,12 @@ class LibraryValidator:
                 self._rtd_yaml_base = ""
 
         return self._rtd_yaml_base
+
+    @staticmethod
+    def get_token_methods():
+        """Return a list of method names that require authentication"""
+
+        return _TOKEN_FUNCTIONS
 
     def run_repo_validation(self, repo):
         """Run all the current validation functions on the provided repository and

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -25,7 +25,7 @@ from adabot import github_requests as gh_reqs
 from adabot.lib import common_funcs
 from adabot.lib import assign_hacktober_label as hacktober
 
-GH_INTERFACE = pygithub.Github(os.environ["ADABOT_GITHUB_ACCESS_TOKEN"])
+GH_INTERFACE = pygithub.Github(os.environ.get("ADABOT_GITHUB_ACCESS_TOKEN"))
 
 
 # Define constants for error strings to make checking against them more robust:
@@ -176,6 +176,13 @@ STD_REPO_LABELS = {
     "good first issue": {"color": "7057ff"},
 }
 
+TOKEN_FUNCTIONS = []
+
+def uses_token(func):
+    """Decorator for recording functions that use tokens"""
+    TOKEN_FUNCTIONS.append(func.__name__)
+    return func
+
 
 class LibraryValidator:
     """Class to hold instance variables needed to traverse the calling
@@ -296,7 +303,7 @@ class LibraryValidator:
         since the last release. Only files that drive user-facing changes
         will be considered when flagging a repo as needing a release.
 
-        If 2), categorize by length of time passed since oldest commit after the release,
+        If 2), categorize by length of ti#me passed since oldest commit after the release,
         and return the number of days that have passed since the oldest commit.
         """
 
@@ -802,6 +809,7 @@ class LibraryValidator:
 
         return errors
 
+    @uses_token
     def validate_readthedocs(self, repo):
         """Method to check the status of `repo`'s ReadTheDocs."""
 
@@ -1137,6 +1145,7 @@ class LibraryValidator:
 
         return errors
 
+    @uses_token
     def validate_actions_state(self, repo):
         """Validate if the most recent GitHub Actions run on the default branch
         has passed.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,15 @@
+# SPDX-FileCopyrightText: 2022 Alec Delaney, for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""Configuration file for pytest (along with `pytest.ini`)"""
+
+
 def pytest_addoption(parser):
     """Add options to the `pytest` command"""
-    parser.addoption("--use-tokens", action="store_true", default=False, help="Test commands that use environment tokens")
+    parser.addoption(
+        "--use-tokens",
+        action="store_true",
+        default=False,
+        help="Test commands that use environment tokens",
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+def pytest_addoption(parser):
+    """Add options to the `pytest` command"""
+    parser.addoption("--use-tokens", action="store_true", default=False, help="Test commands that use environment tokens")

--- a/tests/integration/test_circuitpython_libraries.py
+++ b/tests/integration/test_circuitpython_libraries.py
@@ -10,6 +10,8 @@ from adabot.lib import common_funcs
 from adabot import github_requests
 from adabot import circuitpython_libraries
 
+from adabot.lib import circuitpython_library_validators
+
 # pylint: disable=unused-argument
 def mock_list_repos(*args, **kwargs):
     """Function to monkeypatch `common_funcs.list_repos()` for a shorter set of repos."""
@@ -18,19 +20,32 @@ def mock_list_repos(*args, **kwargs):
     ]
 
 
-def test_circuitpython_libraries(monkeypatch):
+def test_circuitpython_libraries(monkeypatch, pytestconfig):
     """Test main function of 'circuitpyton_libraries.py', without writing an output file."""
 
     monkeypatch.setattr(common_funcs, "list_repos", mock_list_repos)
+
+    # Delete specific tests that require repository secrets
+    # They can't be tested via, so let's remove them and test the others
+    if not pytestconfig.getoption("--use-tokens"):
+        print("FDSFSD")
+        for funcname in circuitpython_library_validators.TOKEN_FUNCTIONS:
+            monkeypatch.delattr(circuitpython_library_validators, funcname)
 
     circuitpython_libraries.main(validator="all")
 
 
 # pylint: disable=invalid-name
-def test_circuitpython_libraries_output_file(monkeypatch, tmp_path, capsys):
+def test_circuitpython_libraries_output_file(monkeypatch, pytestconfig, tmp_path, capsys):
     """Test main funciton of 'circuitpython_libraries.py', with writing an output file."""
 
     monkeypatch.setattr(common_funcs, "list_repos", mock_list_repos)
+
+    # Delete specific tests that require repository secrets
+    # They can't be tested via, so let's remove them and test the others
+    if not pytestconfig.getoption("--use-tokens"):
+        for funcname  in circuitpython_library_validators.TOKEN_FUNCTIONS:
+            monkeypatch.delattr(circuitpython_library_validators, funcname)
 
     tmp_output_file = tmp_path / "output_test.txt"
 

--- a/tests/integration/test_circuitpython_libraries.py
+++ b/tests/integration/test_circuitpython_libraries.py
@@ -30,7 +30,7 @@ def test_circuitpython_libraries(monkeypatch, pytestconfig):
     if not pytestconfig.getoption("--use-tokens"):
         print("FDSFSD")
         for funcname in circuitpython_library_validators.TOKEN_FUNCTIONS:
-            monkeypatch.delattr(circuitpython_library_validators, funcname)
+            monkeypatch.delattr(circuitpython_library_validators.LibraryValidator, funcname)
 
     circuitpython_libraries.main(validator="all")
 
@@ -45,7 +45,7 @@ def test_circuitpython_libraries_output_file(monkeypatch, pytestconfig, tmp_path
     # They can't be tested via, so let's remove them and test the others
     if not pytestconfig.getoption("--use-tokens"):
         for funcname  in circuitpython_library_validators.TOKEN_FUNCTIONS:
-            monkeypatch.delattr(circuitpython_library_validators, funcname)
+            monkeypatch.delattr(circuitpython_library_validators.LibraryValidator, funcname)
 
     tmp_output_file = tmp_path / "output_test.txt"
 

--- a/tests/integration/test_circuitpython_libraries.py
+++ b/tests/integration/test_circuitpython_libraries.py
@@ -28,7 +28,12 @@ def test_circuitpython_libraries(monkeypatch, pytestconfig):
     # Delete specific tests that require repository secrets
     # They can't be tested via, so let's remove them and test the others
     if not pytestconfig.getoption("--use-tokens"):
-        vals = [validator[0] for validator in circuitpython_libraries.default_validators if validator[0] not in circuitpython_library_validators.LibraryValidator.get_token_methods()]
+        vals = [
+            validator[0]
+            for validator in circuitpython_libraries.default_validators
+            if validator[0]
+            not in circuitpython_library_validators.LibraryValidator.get_token_methods()
+        ]
         vals_str = ",".join(vals)
     else:
         vals_str = "all"
@@ -37,13 +42,20 @@ def test_circuitpython_libraries(monkeypatch, pytestconfig):
 
 
 # pylint: disable=invalid-name
-def test_circuitpython_libraries_output_file(monkeypatch, pytestconfig, tmp_path, capsys):
+def test_circuitpython_libraries_output_file(
+    monkeypatch, pytestconfig, tmp_path, capsys
+):
     """Test main funciton of 'circuitpython_libraries.py', with writing an output file."""
 
     # Delete specific tests that require repository secrets
     # They can't be tested via, so let's remove them and test the others
     if not pytestconfig.getoption("--use-tokens"):
-        vals = [validator[0] for validator in circuitpython_libraries.default_validators if validator[0] not in circuitpython_library_validators.LibraryValidator.get_token_methods()]
+        vals = [
+            validator[0]
+            for validator in circuitpython_libraries.default_validators
+            if validator[0]
+            not in circuitpython_library_validators.LibraryValidator.get_token_methods()
+        ]
         vals_str = ",".join(vals)
     else:
         vals_str = "all"

--- a/tests/integration/test_circuitpython_libraries.py
+++ b/tests/integration/test_circuitpython_libraries.py
@@ -28,7 +28,7 @@ def test_circuitpython_libraries(monkeypatch, pytestconfig):
     # Delete specific tests that require repository secrets
     # They can't be tested via, so let's remove them and test the others
     if not pytestconfig.getoption("--use-tokens"):
-        vals = [validator for validator in circuitpython_libraries.default_validators if validator not in circuitpython_library_validators.TOKEN_FUNCTIONS]
+        vals = [validator[0] for validator in circuitpython_libraries.default_validators if validator not in circuitpython_library_validators.TOKEN_FUNCTIONS]
         vals_str = ",".join(vals)
     else:
         vals_str = "all"
@@ -43,7 +43,7 @@ def test_circuitpython_libraries_output_file(monkeypatch, pytestconfig, tmp_path
     # Delete specific tests that require repository secrets
     # They can't be tested via, so let's remove them and test the others
     if not pytestconfig.getoption("--use-tokens"):
-        vals = [validator for validator in circuitpython_libraries.default_validators if validator not in circuitpython_library_validators.TOKEN_FUNCTIONS]
+        vals = [validator[0] for validator in circuitpython_libraries.default_validators if validator not in circuitpython_library_validators.TOKEN_FUNCTIONS]
         vals_str = ",".join(vals)
     else:
         vals_str = "all"

--- a/tests/integration/test_circuitpython_libraries.py
+++ b/tests/integration/test_circuitpython_libraries.py
@@ -47,6 +47,8 @@ def test_circuitpython_libraries_output_file(
 ):
     """Test main funciton of 'circuitpython_libraries.py', with writing an output file."""
 
+    monkeypatch.setattr(common_funcs, "list_repos", mock_list_repos)
+
     # Delete specific tests that require repository secrets
     # They can't be tested via, so let's remove them and test the others
     if not pytestconfig.getoption("--use-tokens"):

--- a/tests/integration/test_circuitpython_libraries.py
+++ b/tests/integration/test_circuitpython_libraries.py
@@ -28,7 +28,7 @@ def test_circuitpython_libraries(monkeypatch, pytestconfig):
     # Delete specific tests that require repository secrets
     # They can't be tested via, so let's remove them and test the others
     if not pytestconfig.getoption("--use-tokens"):
-        vals = [validator[0] for validator in circuitpython_libraries.default_validators if validator not in circuitpython_library_validators.TOKEN_FUNCTIONS]
+        vals = [validator[0] for validator in circuitpython_libraries.default_validators if validator[0] not in circuitpython_library_validators.LibraryValidator.get_token_methods()]
         vals_str = ",".join(vals)
     else:
         vals_str = "all"
@@ -43,7 +43,7 @@ def test_circuitpython_libraries_output_file(monkeypatch, pytestconfig, tmp_path
     # Delete specific tests that require repository secrets
     # They can't be tested via, so let's remove them and test the others
     if not pytestconfig.getoption("--use-tokens"):
-        vals = [validator[0] for validator in circuitpython_libraries.default_validators if validator not in circuitpython_library_validators.TOKEN_FUNCTIONS]
+        vals = [validator[0] for validator in circuitpython_libraries.default_validators if validator[0] not in circuitpython_library_validators.LibraryValidator.get_token_methods()]
         vals_str = ",".join(vals)
     else:
         vals_str = "all"

--- a/tests/integration/test_circuitpython_libraries.py
+++ b/tests/integration/test_circuitpython_libraries.py
@@ -28,28 +28,29 @@ def test_circuitpython_libraries(monkeypatch, pytestconfig):
     # Delete specific tests that require repository secrets
     # They can't be tested via, so let's remove them and test the others
     if not pytestconfig.getoption("--use-tokens"):
-        print("FDSFSD")
-        for funcname in circuitpython_library_validators.TOKEN_FUNCTIONS:
-            monkeypatch.delattr(circuitpython_library_validators.LibraryValidator, funcname)
+        vals = [validator for validator in circuitpython_libraries.default_validators if validator not in circuitpython_library_validators.TOKEN_FUNCTIONS]
+        vals_str = ",".join(vals)
+    else:
+        vals_str = "all"
 
-    circuitpython_libraries.main(validator="all")
+    circuitpython_libraries.main(validator=vals_str)
 
 
 # pylint: disable=invalid-name
 def test_circuitpython_libraries_output_file(monkeypatch, pytestconfig, tmp_path, capsys):
     """Test main funciton of 'circuitpython_libraries.py', with writing an output file."""
 
-    monkeypatch.setattr(common_funcs, "list_repos", mock_list_repos)
-
     # Delete specific tests that require repository secrets
     # They can't be tested via, so let's remove them and test the others
     if not pytestconfig.getoption("--use-tokens"):
-        for funcname  in circuitpython_library_validators.TOKEN_FUNCTIONS:
-            monkeypatch.delattr(circuitpython_library_validators.LibraryValidator, funcname)
+        vals = [validator for validator in circuitpython_libraries.default_validators if validator not in circuitpython_library_validators.TOKEN_FUNCTIONS]
+        vals_str = ",".join(vals)
+    else:
+        vals_str = "all"
 
     tmp_output_file = tmp_path / "output_test.txt"
 
-    circuitpython_libraries.main(validator="all", output_file=tmp_output_file)
+    circuitpython_libraries.main(validator=vals_str, output_file=tmp_output_file)
 
     captured = capsys.readouterr()
 


### PR DESCRIPTION
Fixes the issue where the CI can't test certain validators in pull requests because secrets cannot be passed to them.  Instead, this will have to be done locally, which should be a decent workaround if they ever need to be tested during development.