### PR TITLE
PyPI infrastructure checks

### DIFF
--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -81,6 +81,7 @@ ERROR_MISSING_READTHEDOCS = "Missing readthedocs.yaml"
 ERROR_MISSING_PYPROJECT_TOML = "For PyPI compatibility, missing pyproject.toml"
 ERROR_MISSING_PRE_COMMIT_CONFIG = "Missing .pre-commit-config.yaml"
 ERROR_MISSING_REQUIREMENTS_TXT = "For PyPI compatibility, missing requirements.txt"
+ERROR_SETUP_PY_EXISTS = "Library uses setup.py, needs to be converted to pyproject.toml"
 ERROR_MISSING_OPTIONAL_REQUIREMENTS_TXT = (
     "For PyPI compatibility, missing optional_requirements.txt"
 )
@@ -704,6 +705,9 @@ class LibraryValidator:
 
         if "pyproject.toml.disabled" in files:
             errors.append(ERROR_MISSING_PYPROJECT_TOML)
+
+        if "setup.py" in files:
+            errors.append(ERROR_SETUP_PY_EXISTS)
 
         if repo["name"] not in self.has_pyproject_toml_disabled:
             if "requirements.txt" in files:

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -701,7 +701,8 @@ class LibraryValidator:
         if "pyproject.toml" in files:
             file_info = content_list[files.index("pyproject.toml")]
             errors.extend(self._validate_pyproject_toml(file_info))
-        elif "pyproject.toml.disabled" not in files:
+
+        if "pyproject.toml.disabled" in files:
             errors.append(ERROR_MISSING_PYPROJECT_TOML)
 
         if repo["name"] not in self.has_pyproject_toml_disabled:

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -702,8 +702,7 @@ class LibraryValidator:
         if "pyproject.toml" in files:
             file_info = content_list[files.index("pyproject.toml")]
             errors.extend(self._validate_pyproject_toml(file_info))
-
-        if "pyproject.toml.disabled" in files:
+        else:
             errors.append(ERROR_MISSING_PYPROJECT_TOML)
 
         if "setup.py" in files:


### PR DESCRIPTION
- Now raises error if `setup.py` is found in the repo (should be using `pyproject.toml`)
- Now raises error if `pyproject.toml` is not present (regardless of presence of `pyproject.toml.disabled`