### PR TITLE
Use API call to find unassigned issues in core

### DIFF
--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -203,7 +203,7 @@ def run_library_checks(validators, kw_args, error_depth):
     ]
     logger.info(
         "  * %s issues not assigned a milestone",
-        len(no_milsestone_issues),
+        len(no_milestone_issues),
     )
     logger.info("")
 

--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -195,12 +195,6 @@ def run_library_checks(validators, kw_args, error_depth):
     logger.info("* %s open issues", len(core_insights["open_issues"]))
     logger.info("  * https://github.com/adafruit/circuitpython/issues")
     logger.info("* %s active milestones", len(core_insights["milestones"]))
-    ms_count = 0
-    for milestone in sorted(core_insights["milestones"].keys()):
-        ms_count += core_insights["milestones"][milestone]
-        logger.info(
-            "  * %s: %s open issues", milestone, core_insights["milestones"][milestone]
-        )
     no_milsestone_items = gh_reqs.get(
         "/repos/adafruit/circuitpython/issues?milestone=none"
     ).json()

--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -201,9 +201,15 @@ def run_library_checks(validators, kw_args, error_depth):
         logger.info(
             "  * %s: %s open issues", milestone, core_insights["milestones"][milestone]
         )
+    no_milsestone_items = gh_reqs.get(
+        "/repos/adafruit/circuitpython/issues?milestone=none"
+    ).json()
+    no_milsestone_issues = [
+        item for item in no_milsestone_items if "pull_request" not in item
+    ]
     logger.info(
         "  * %s issues not assigned a milestone",
-        len(core_insights["open_issues"]) - ms_count,
+        len(no_milsestone_issues),
     )
     logger.info("")
 

--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -195,11 +195,11 @@ def run_library_checks(validators, kw_args, error_depth):
     logger.info("* %s open issues", len(core_insights["open_issues"]))
     logger.info("  * https://github.com/adafruit/circuitpython/issues")
     logger.info("* %s active milestones", len(core_insights["milestones"]))
-    no_milsestone_items = gh_reqs.get(
+    no_milestone_items = gh_reqs.get(
         "/repos/adafruit/circuitpython/issues?milestone=none"
     ).json()
-    no_milsestone_issues = [
-        item for item in no_milsestone_items if "pull_request" not in item
+    no_milestone_issues = [
+        item for item in no_milestone_items if "pull_request" not in item
     ]
     logger.info(
         "  * %s issues not assigned a milestone",


### PR DESCRIPTION
Fixes the issue where the reports say there are -2 issues unassigned to milestone.  This changes the math that was happening to a simple API call to the core repository.