### PR TITLE
Fix getting repo using PyGithub

### DIFF
--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -866,7 +866,7 @@ class LibraryValidator:
         # Get the README file contents
         while True:
             try:
-                lib_repo = GH_INTERFACE.get_repo("Adafruit/" + repo["full_name"])
+                lib_repo = GH_INTERFACE.get_repo(repo["full_name"])
                 content_file = lib_repo.get_contents("README.rst")
                 break
             except pygithub.RateLimitExceededException:


### PR DESCRIPTION
This should be the cause of the current failure in the Library Infrastructure Issues page on circuitpython.org

After merging, circuitpython-org will need to be updated to include this change.