### PR TITLE
Fix new/updated libraries formatting

### DIFF
--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -245,15 +245,16 @@ def run_library_checks(validators, kw_args, error_depth):
 
     logger.info("* https://circuitpython.org/contributing")
 
-    logger.info("Library updates in the last seven days:")
+    logger.info("")
+    logger.info("#### Library updates in the last seven days:")
     if len(new_libs) != 0:
-        logger.info("**New Libraries**")
+        logger.info("* **New Libraries**")
         for title, link in new_libs.items():
-            logger.info(" * [%s](%s)", title, link)
+            logger.info("  * [%s](%s)", title, link)
     if len(updated_libs) != 0:
-        logger.info("**Updated Libraries**")
+        logger.info("* **Updated Libraries**")
         for title, link in updated_libs.items():
-            logger.info(" * [%s](%s)", title, link)
+            logger.info("  * [%s](%s)", title, link)
 
     if len(validators) != 0:
         lib_repos = []


### PR DESCRIPTION
Fixes formatting for the new/updated libraries section of the weekly meeting text.  I attached a file showing what it should be after this change.

[circuitpython_library_report_20220907.md](https://github.com/adafruit/adabot/files/9523042/circuitpython_library_report_20220907.md)
