### PR TITLE
Readd printing active milestones and their issue counts

### DIFF
--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -195,9 +195,7 @@ def run_library_checks(validators, kw_args, error_depth):
     logger.info("* %s open issues", len(core_insights["open_issues"]))
     logger.info("  * https://github.com/adafruit/circuitpython/issues")
     logger.info("* %s active milestones", len(core_insights["milestones"]))
-    for milestone, milestone_issue_count in sorted(
-        core_insights["milestones"].items()
-    ):
+    for milestone, milestone_issue_count in sorted(core_insights["milestones"].items()):
         logger.info(" * %s: %s open issues", milestone, milestone_issue_count)
     no_milestone_items = gh_reqs.get(
         "/repos/adafruit/circuitpython/issues?milestone=none"

--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -195,10 +195,10 @@ def run_library_checks(validators, kw_args, error_depth):
     logger.info("* %s open issues", len(core_insights["open_issues"]))
     logger.info("  * https://github.com/adafruit/circuitpython/issues")
     logger.info("* %s active milestones", len(core_insights["milestones"]))
-    for milestone, milestone_issue_count in sorted(core_insights["open_issues"].items()):
-        logger.info(
-            " * %s: %s open issues", milestone, milestone_issue_count
-        )
+    for milestone, milestone_issue_count in sorted(
+        core_insights["milestones"].items()
+    ):
+        logger.info(" * %s: %s open issues", milestone, milestone_issue_count)
     no_milestone_items = gh_reqs.get(
         "/repos/adafruit/circuitpython/issues?milestone=none"
     ).json()

--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -195,6 +195,10 @@ def run_library_checks(validators, kw_args, error_depth):
     logger.info("* %s open issues", len(core_insights["open_issues"]))
     logger.info("  * https://github.com/adafruit/circuitpython/issues")
     logger.info("* %s active milestones", len(core_insights["milestones"]))
+    for milestone, milestone_issue_count in sorted(core_insights["open_issues"].items()):
+        logger.info(
+            " * %s: %s open issues", milestone, milestone_issue_count
+        )
     no_milestone_items = gh_reqs.get(
         "/repos/adafruit/circuitpython/issues?milestone=none"
     ).json()


### PR DESCRIPTION
Fixes the issue introduced in #297 which accidentally removed the code that printed the active milestones for the core and their issues counts.  Whoever wrote that PR should have realized that 😆 