### PR TITLE
Add weekly PyPI stats to daily report

### DIFF
--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -9,6 +9,7 @@ import argparse
 import datetime
 import inspect
 import logging
+import os
 import re
 import sys
 import traceback
@@ -216,6 +217,27 @@ def run_library_checks(validators, kw_args, error_depth):
     logger.info("* Core download stats available at https://circuitpython.org/stats")
 
     logger.info("")
+
+    # Get PyPI stats
+    if os.environ.get("BIGQUERY_PRIVATE_KEY") and os.environ["BIGQUERY_CLIENT_EMAIL"]:
+        pypi_stats = dl_stats.retrieve_pypi_stats(repos)
+        library_pypi_names = [
+            repo["name"].replace("_", "-").lower() for repo in common_funcs.list_repos()
+        ]
+        total_library_pypi_stats = 0
+        library_pypi_stats = [
+            stat for stat in pypi_stats if stat.name in library_pypi_names
+        ]
+        top_library_pypi_stats = library_pypi_stats[:10]
+        total_library_pypi_stats = 0
+        for stat in library_pypi_stats:
+            total_library_pypi_stats += stat.num_downloads
+        blinka_pypi_stats = [
+            stat for stat in pypi_stats if stat.name == "adafruit-blinka"
+        ][0]
+    else:
+        pypi_stats = None
+
     logger.info("### Libraries")
     print_pr_overview(lib_insights)
     logger.info("  * Merged pull requests:")
@@ -246,6 +268,30 @@ def run_library_checks(validators, kw_args, error_depth):
     logger.info("  * %s good first issues", lib_insights["good_first_issues"])
 
     logger.info("* https://circuitpython.org/contributing")
+
+    logger.info("")
+    logger.info("#### Library PyPI Weekly Download Stats")
+    if pypi_stats:
+        logger.info("* **Total Library Stats**")
+        logger.info(
+            "  * %d PyPI downloads over %d libraries",
+            total_library_pypi_stats,
+            len(library_pypi_names),
+        )
+        logger.info("* **Top 10 Libraries by PyPI Downloads**")
+        for lib_stat in top_library_pypi_stats:
+            logger.info(
+                "  * %s: %d",
+                lib_stat.name,
+                lib_stat.num_downloads,
+            )
+    else:
+        logger.info(
+            "*This info is not printed because the cron is unable to access secrets.*"
+        )
+        logger.info(
+            "*This is expected if this was run as part of the CI for a pull request.*"
+        )
 
     logger.info("")
     logger.info("#### Library updates in the last seven days:")
@@ -295,7 +341,20 @@ def run_library_checks(validators, kw_args, error_depth):
     print_issue_overview(blinka_insights)
     logger.info("* %s open issues", len(blinka_insights["open_issues"]))
     logger.info("  * https://github.com/adafruit/Adafruit_Blinka/issues")
-    blinka_dl = dl_stats.piwheels_stats().get("adafruit-blinka", {}).get("month", "N/A")
+    blinka_dl = (
+        dl_stats.retrieve_piwheels_stats()
+        .get("adafruit-blinka", {})
+        .get("month", "N/A")
+    )
+    if pypi_stats:
+        logger.info(
+            "* PyPI downloads in the last week: %d",
+            blinka_pypi_stats.num_downloads,
+        )
+    else:
+        logger.info(
+            "* PyPI download stats unavailable - this is normal for CI runs triggered by PRs"
+        )
     logger.info("* Piwheels Downloads in the last month: %s", blinka_dl)
     logger.info("Number of supported boards: %s", blinka_funcs.board_count())
 

--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -177,6 +177,13 @@ def run_library_checks(validators, kw_args, error_depth):
     logger.info("")
     logger.info("State of CircuitPython + Libraries + Blinka")
 
+    logger.info("")
+    logger.info("**This report contains information from the previous seven days.**")
+    logger.info(
+        "**Any changes (PRs merged, etc.) made today are not included in this report.**"
+    )
+    logger.info("")
+
     logger.info("### Overall")
     print_pr_overview(lib_insights, core_insights, blinka_insights)
     print_issue_overview(lib_insights, core_insights, blinka_insights)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ parse==1.19.0
 GitPython==3.1.27
 PyGithub==1.55
 typing-extensions~=4.0
+google-auth~=2.13
+google-cloud-bigquery~=3.3


### PR DESCRIPTION
Adds the PyPI stats to the daily report, which it pulls from Google's BigQuery.  Passed the `pytest` cases locally.

I'll work on have this auto-push commits to the bundle next.
