### PR TITLE
Update pylint version check reference

### DIFF
--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -557,7 +557,7 @@ class LibraryValidator:
             errors.append(ERROR_PRE_COMMIT_VERSION)
 
         pylint_repo = "repo: https://github.com/pycqa/pylint"
-        pylint_version = "rev: v2.11.1"
+        pylint_version = "rev: v2.15.5"
 
         if pylint_repo not in text or pylint_version not in text:
             errors.append(ERROR_PYLINT_VERSION)


### PR DESCRIPTION
New pylint, new update to adabot!

Fixes the check adabot does to compare to the newly updated version.