### PR TITLE
Fix actions success check

### DIFF
--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -1217,7 +1217,7 @@ class LibraryValidator:
                 except pygithub.GithubException:  # This can probably be tightened later
                     # No workflows or runs yet
                     return []
-                if not workflow_runs[0].conclusion:
+                if workflow_runs[0].conclusion != "success":
                     return [ERROR_CI_BUILD]
                 return []
             except pygithub.RateLimitExceededException:


### PR DESCRIPTION
Fixed a bug in adabot for checking the latest CI run result.  It does not return a boolean, but rather a string, so it needs to check the value and not just the truthiness.