### PR TITLE
Announce community bundle updates

### DIFF
--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -23,6 +23,7 @@ from adabot.lib import circuitpython_library_validators as cirpy_lib_vals
 from adabot.lib import common_funcs
 from adabot.lib import assign_hacktober_label as hacktober
 from adabot.lib import blinka_funcs
+from adabot.lib import community_bundle_announcer
 from adabot import circuitpython_library_download_stats as dl_stats
 
 GH_INTERFACE = pygithub.Github(os.environ.get("ADABOT_GITHUB_ACCESS_TOKEN"))
@@ -340,6 +341,19 @@ def run_library_checks(validators, kw_args, error_depth):
     if len(updated_libs) != 0:
         logger.info("* **Updated Libraries**")
         for title, link in updated_libs.items():
+            logger.info("  * [%s](%s)", title, link)
+
+    (
+        new_community_libs,
+        updated_community_libs,
+    ) = community_bundle_announcer.get_community_bundle_updates()
+    if len(new_community_libs) != 0:
+        logger.info("* **New Community Libraries**")
+        for title, link in new_community_libs:
+            logger.info("  * [%s](%s)", title, link)
+    if len(updated_community_libs) != 0:
+        logger.info("* **Updated Community Libraries**")
+        for title, link in updated_community_libs:
             logger.info("  * [%s](%s)", title, link)
 
     if len(validators) != 0:

--- a/adabot/lib/community_bundle_announcer.py
+++ b/adabot/lib/community_bundle_announcer.py
@@ -75,6 +75,9 @@ def get_community_bundle_updates() -> Tuple[Set[RepoResult], Set[RepoResult]]:
             logging.warning("Rate Limit will reset at: %s", core_rate_limit_reset)
             time.sleep(sleep_time.seconds)
             continue
+        except pygithub.GithubException:
+            # Secrets may not be available or error occurred - just skip
+            return (set(), set())
 
 
 if __name__ == "__main__":

--- a/adabot/lib/community_bundle_announcer.py
+++ b/adabot/lib/community_bundle_announcer.py
@@ -56,16 +56,17 @@ def get_community_bundle_updates() -> Tuple[Set[RepoResult], Set[RepoResult]]:
                         x.strip(",") for x in relevant_line.split(" ")[2:]
                     ]
                     for lib in lib_components:
-                        comps = parse.parse("[{name:S}]({link:S})", lib)
-                        link: str = parse.search("{repo:S}/releases", comps["link"])[
-                            "repo"
-                        ]
-                    update_set = (
-                        updated_libs
-                        if relevant_line.startswith("Updated libraries")
-                        else new_libs
-                    )
-                    update_set.add((comps["name"], link))
+                        comps = parse.parse("[{name:S}]({link_comp:S})", lib)
+                        link: str = parse.search(
+                            "{link:S}/releases", comps["link_comp"]
+                        )["link"]
+                        full_name = parse.search(
+                            "https://github.com/{full_name:S}", link
+                        )["full_name"]
+                    if relevant_line.startswith("Updated libraries"):
+                        updated_libs.add((full_name, link))
+                    else:
+                        new_libs.add((full_name, link))
             return (new_libs, updated_libs)
 
         except pygithub.RateLimitExceededException:

--- a/adabot/lib/community_bundle_announcer.py
+++ b/adabot/lib/community_bundle_announcer.py
@@ -9,11 +9,15 @@ on the automated release.
 * Author(s): Alec Delaney
 """
 
+import datetime
+import logging
 import os
-from typing import Tuple
+import time
+from typing import Tuple, Set
 from typing_extensions import TypeAlias
 
 import github as pygithub
+import parse
 
 GH_INTERFACE = pygithub.Github(os.environ.get("ADABOT_GITHUB_ACCESS_TOKEN"))
 
@@ -21,5 +25,60 @@ RepoResult: TypeAlias = Tuple[str, str]
 """(Submodule Name, Full Repo Name)"""
 
 
-def get_community_bundle_updates() -> Tuple[RepoResult, RepoResult]:
-    """"""
+def get_community_bundle_updates() -> Tuple[Set[RepoResult], Set[RepoResult]]:
+    """
+    Get the updates to the Community Bundle.
+
+    Returns new and updated libraries
+    """
+    while True:
+        try:
+            repository = GH_INTERFACE.get_repo(
+                "adafruit/CircuitPython_Community_Bundle"
+            )
+            seven_days_ago = datetime.datetime.now() - datetime.timedelta(days=7)
+            recent_releases = [
+                release
+                for release in repository.get_releases()
+                if release.created_at > seven_days_ago
+            ]
+            new_libs = set()
+            updated_libs = set()
+            for recent_release in recent_releases:
+                relevant_lines = [
+                    line
+                    for line in recent_release.body.split("\n")
+                    if line.startswith("Updated libraries")
+                    or line.startswith("New libraries:")
+                ]
+                for relevant_line in relevant_lines:
+                    lib_components = [
+                        x.strip(",") for x in relevant_line.split(" ")[2:]
+                    ]
+                    for lib in lib_components:
+                        comps = parse.parse("[{name:S}]({link:S})", lib)
+                        link: str = parse.search("{repo:S}/releases", comps["link"])[
+                            "repo"
+                        ]
+                    update_set = (
+                        updated_libs
+                        if relevant_line.startswith("Updated libraries")
+                        else new_libs
+                    )
+                    update_set.add((comps["name"], link))
+            return (new_libs, updated_libs)
+
+        except pygithub.RateLimitExceededException:
+            core_rate_limit_reset = GH_INTERFACE.get_rate_limit().core.reset
+            sleep_time = core_rate_limit_reset - datetime.datetime.now()
+            logging.warning("Rate Limit will reset at: %s", core_rate_limit_reset)
+            time.sleep(sleep_time.seconds)
+            continue
+
+
+if __name__ == "__main__":
+    results = get_community_bundle_updates()
+    for new_lib in results[0]:
+        print(f"New libraries: {new_lib[0]} { {new_lib[1]} }")
+    for updated_lib in results[1]:
+        print(f"New libraries: {updated_lib[0]} { {updated_lib[1]} }")

--- a/adabot/lib/community_bundle_announcer.py
+++ b/adabot/lib/community_bundle_announcer.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2022 Alec Delaney, for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Checks for the latest releases in the Community bundle based
+on the automated release.
+
+* Author(s): Alec Delaney
+"""
+
+import os
+from typing import Tuple
+from typing_extensions import TypeAlias
+
+import github as pygithub
+
+GH_INTERFACE = pygithub.Github(os.environ.get("ADABOT_GITHUB_ACCESS_TOKEN"))
+
+RepoResult: TypeAlias = Tuple[str, str]
+"""(Submodule Name, Full Repo Name)"""
+
+
+def get_community_bundle_updates() -> Tuple[RepoResult, RepoResult]:
+    """"""


### PR DESCRIPTION
More love for the community bundle!  This resolves #201 by adding an announcement in the "Libraries" section if any of the community bundle libraries are new or updated within the last seven days.

I implemented it in a different way than it checks the Adafruit Bundle because that way uses a couple calls for each library, whereas this this only makes a couple requests to GitHub (600 vs 2).  Might be worth switch to using this method for the others as well.