### PR TITLE
Allow running reports CI on demand

### DIFF
--- a/.github/workflows/reports_cron.yml
+++ b/.github/workflows/reports_cron.yml
@@ -8,7 +8,7 @@ on:
   schedule:
     - cron: 15 5 * * *
   workflow_dispatch:
-    
+
 
 jobs:
   check-repo-owner:

--- a/.github/workflows/reports_cron.yml
+++ b/.github/workflows/reports_cron.yml
@@ -7,6 +7,8 @@ name: Run Daily Reports
 on:
   schedule:
     - cron: 15 5 * * *
+  workflow_dispatch:
+    
 
 jobs:
   check-repo-owner:
@@ -79,6 +81,7 @@ jobs:
         run: |
           ls bin/adabot
       - name: Upload Reports To AWS S3
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
This allows the report CI to be run on demand.  Doesn't upload reports to AWS S3 in that case.