### PR TITLE
Add patch for pylint, jQuery

### DIFF
--- a/patches/14MAY2023_pylintrc_jquery.patch
+++ b/patches/14MAY2023_pylintrc_jquery.patch
@@ -1,0 +1,45 @@
+From 6467782ca1523e6d77cb6b857d16d6d6df1feeb7 Mon Sep 17 00:00:00 2001
+From: Tekktrik <tekktrik@gmail.com>
+Date: Sun, 14 May 2023 13:00:32 -0400
+Subject: [PATCH] Update .pylintrc, fix jQuery for docs
+
+---
+ .pylintrc             | 2 +-
+ docs/conf.py          | 1 +
+ docs/requirements.txt | 1 +
+ 3 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/.pylintrc b/.pylintrc
+index 40208c3..f945e92 100644
+--- a/.pylintrc
++++ b/.pylintrc
+@@ -396,4 +396,4 @@ min-public-methods=1
+ 
+ # Exceptions that will emit a warning when being caught. Defaults to
+ # "Exception"
+-overgeneral-exceptions=Exception
++overgeneral-exceptions=builtins.Exception
+diff --git a/docs/conf.py b/docs/conf.py
+index 7c368fb..f24dd46 100644
+--- a/docs/conf.py
++++ b/docs/conf.py
+@@ -17,6 +17,7 @@ sys.path.insert(0, os.path.abspath(".."))
+ # ones.
+ extensions = [
+     "sphinx.ext.autodoc",
++    "sphinxcontrib.jquery",
+     "sphinx.ext.intersphinx",
+     "sphinx.ext.napoleon",
+     "sphinx.ext.todo",
+diff --git a/docs/requirements.txt b/docs/requirements.txt
+index 88e6733..797aa04 100644
+--- a/docs/requirements.txt
++++ b/docs/requirements.txt
+@@ -3,3 +3,4 @@
+ # SPDX-License-Identifier: Unlicense
+ 
+ sphinx>=4.0.0
++sphinxcontrib-jquery
+-- 
+2.40.1
+


### PR DESCRIPTION
- Updates `.pylintrc` to fix `pylint` warning for specifying exceptions in `overgeneral-exceptions`
- Fixes jQuery for Sphinx

Paired with https://github.com/adafruit/cookiecutter-adafruit-circuitpython/pull/228