### PR TITLE
adding patch for sphinx-rtd-theme in docs/reqs

### DIFF
--- a/patches/11OCT2023-add-sphinx-rtd-theme-to-docs-reqs.patch
+++ b/patches/11OCT2023-add-sphinx-rtd-theme-to-docs-reqs.patch
@@ -1,0 +1,21 @@
+From 364a28bd7385e1df0f2faf0b8cec5764b096bacc Mon Sep 17 00:00:00 2001
+From: foamyguy <foamyguy@gmail.com>
+Date: Mon, 16 Oct 2023 09:55:57 -0500
+Subject: [PATCH] add sphinx-rtd-theme to docs/reqs.txt
+
+---
+ docs/requirements.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/docs/requirements.txt b/docs/requirements.txt
+index 797aa04..9ccaf8e 100644
+--- a/docs/requirements.txt
++++ b/docs/requirements.txt
+@@ -4,3 +4,4 @@
+ 
+ sphinx>=4.0.0
+ sphinxcontrib-jquery
++sphinx-rtd-theme
+-- 
+2.34.1
+

--- a/patches/11OCT2023-add-sphinx-rtd-theme-to-docs-reqs.patch
+++ b/patches/11OCT2023-add-sphinx-rtd-theme-to-docs-reqs.patch
@@ -14,11 +14,11 @@ index 797aa04..979f568 100644
 @@ -2,5 +2,6 @@
  #
  # SPDX-License-Identifier: Unlicense
-
+ 
 -sphinx>=4.0.0
 +sphinx
  sphinxcontrib-jquery
 +sphinx-rtd-theme
---
+-- 
 2.34.1
 

--- a/patches/11OCT2023-add-sphinx-rtd-theme-to-docs-reqs.patch
+++ b/patches/11OCT2023-add-sphinx-rtd-theme-to-docs-reqs.patch
@@ -1,21 +1,24 @@
-From 364a28bd7385e1df0f2faf0b8cec5764b096bacc Mon Sep 17 00:00:00 2001
+From 6ac5e49df667e54aef02f5181b41b233be7a4bf3 Mon Sep 17 00:00:00 2001
 From: foamyguy <foamyguy@gmail.com>
-Date: Mon, 16 Oct 2023 09:55:57 -0500
-Subject: [PATCH] add sphinx-rtd-theme to docs/reqs.txt
+Date: Mon, 16 Oct 2023 14:30:31 -0500
+Subject: [PATCH] unpin sphinx and add sphinx-rtd-theme to docs reqs
 
 ---
- docs/requirements.txt | 1 +
- 1 file changed, 1 insertion(+)
+ docs/requirements.txt | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/docs/requirements.txt b/docs/requirements.txt
-index 797aa04..9ccaf8e 100644
+index 797aa04..979f568 100644
 --- a/docs/requirements.txt
 +++ b/docs/requirements.txt
-@@ -4,3 +4,4 @@
- 
- sphinx>=4.0.0
+@@ -2,5 +2,6 @@
+ #
+ # SPDX-License-Identifier: Unlicense
+
+-sphinx>=4.0.0
++sphinx
  sphinxcontrib-jquery
 +sphinx-rtd-theme
--- 
+--
 2.34.1
 


### PR DESCRIPTION
patch that adds `sphinx-rtd-theme` into `docs/requirements.txt` which is needed since a change in RTD behavior starting 10/3 outlined in this post: https://blog.readthedocs.com/defaulting-latest-build-tools/ 

For our usage the crux is that `sphinx-rtd-theme` used to be installed automatically, but no longer is so we need to specify it in a requirements file in order for it to be installed moving forward.