### PR TITLE
turn up the debug level

### DIFF
--- a/adabot/github_requests.py
+++ b/adabot/github_requests.py
@@ -82,6 +82,9 @@ def request(method, url, **kwargs):
             "See log for error text that has been sanitized for secrets"
         ) from None
 
+    if not from_cache:
+        if remaining % 100 == 0 or remaining < 20:
+            logging.info("%d requests remaining this hour", remaining)
     if not from_cache and remaining <= 1:
         rate_limit_reset = datetime.datetime.fromtimestamp(
             int(response.headers["X-RateLimit-Reset"])
@@ -95,9 +98,6 @@ def request(method, url, **kwargs):
 
             logging.info("Sleeping %s seconds", reset_diff.seconds)
             time.sleep(reset_diff.seconds + 1)
-
-        if remaining % 100 == 0:
-            logging.info(remaining, "requests remaining this hour")
 
     return response
 

--- a/adabot/update_cp_org_libraries.py
+++ b/adabot/update_cp_org_libraries.py
@@ -21,7 +21,7 @@ from adabot import pypi_requests as pypi
 
 logger = logging.getLogger(__name__)
 ch = logging.StreamHandler(stream=sys.stdout)
-logging.basicConfig(format="%(message)s", handlers=[ch])
+logging.basicConfig(level=logging.DEBUG, format="%(message)s", handlers=[ch])
 
 
 DO_NOT_VALIDATE = [


### PR DESCRIPTION
We still don't know what exactly is causing #263 -- a recent log showed some odd attempt to sleep to avoid a rate limit, but then no further activity was shown for several hours until the job was terminated, much longer than the expected sleep:
```
Fri, 24 Nov 2023 09:20:27 GMT  - Report output will be saved to: /home/runner/work/circuitpython-org/circuitpython-org/bin/adabot/libraries.v2.json
Fri, 24 Nov 2023 10:06:30 GMT GitHub API Rate Limit reached. Pausing until Rate Limit reset.
Fri, 24 Nov 2023 10:20:39 GMT Rate Limit will reset at: 2023-11-24 10:20:39
Fri, 24 Nov 2023 10:20:39 GMT GitHub API Rate Limit reached. Pausing until Rate Limit reset.
Fri, 24 Nov 2023 10:20:39 GMT Rate Limit will reset at: 2023-11-24 10:20:39
Fri, 24 Nov 2023 15:20:09 GMT Error: The operation was canceled.
```
(timestamps available via the "show timestamps" option in the gear menu)

this will turn on a substantial amount of additional debug info, something like (based on a local run)
```
GET https://api.github.com/search/repositories?q=Adafruit_CircuitPython+user%3Aadafruit+archived%3Afalse+fork%3Atrue&per_page=100&sort=updated&order=asc&page=4 (2 remaining) status=200
2 requests remaining this hour
Starting new HTTPS connection (1): api.github.com:443
https://api.github.com:443 "GET /repos/adafruit/circuitpython HTTP/1.1" 403 277
GET /repos/adafruit/circuitpython (0 remaining) status=403
0 requests remaining this hour
GitHub API Rate Limit reached. Pausing until Rate Limit reset.
Rate Limit will reset at: 2023-11-24 10:27:01
Sleeping 3263 seconds
```