### PR TITLE
Continue trying to diagnose & fix timeout problem

### DIFF
--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -258,8 +258,19 @@ def run_library_checks(validators, kw_args, error_depth):
         except pygithub.RateLimitExceededException:
             core_rate_limit_reset = GH_INTERFACE.get_rate_limit().core.reset
             sleep_time = core_rate_limit_reset - datetime.datetime.utcnow()
-            logging.warning("Rate Limit will reset at: %s", core_rate_limit_reset)
-            time.sleep(sleep_time.seconds)
+            logging.warning(
+                "Rate Limit will reset at: %s, sleeping %s",
+                core_rate_limit_reset,
+                sleep_time,
+            )
+            logging.warning(
+                "now=%s utcnow=%s", datetime.datetime.now(), datetime.datetime.utcnow()
+            )
+            sleep_seconds = sleep_time.total_seconds() + 60
+            if sleep_seconds > 3600:
+                sleep_seconds = 3600
+                print("limiting sleep time to 3600 seconds")
+            time.sleep(sleep_seconds)
             continue
         except pygithub.GithubException:
             break

--- a/adabot/github_requests.py
+++ b/adabot/github_requests.py
@@ -101,8 +101,12 @@ def request(method, url, **kwargs):
             logging.warning("Rate Limit will reset at: %s", rate_limit_reset)
             reset_diff = rate_limit_reset - datetime.datetime.now()
 
-            logging.info("Sleeping %s seconds", reset_diff.seconds)
-            time.sleep(reset_diff.seconds + 1)
+            sleep_seconds = reset_diff.total_seconds() + 60
+            logging.info("Sleeping %s seconds", sleep_seconds)
+            if sleep_seconds > 3600:
+                sleep_seconds = 3600
+                print("limiting sleep time to 3600 seconds")
+            time.sleep(sleep_seconds)
 
     return response
 

--- a/adabot/lib/bundle_announcer.py
+++ b/adabot/lib/bundle_announcer.py
@@ -81,8 +81,19 @@ def get_bundle_updates(full_repo_name: str) -> Tuple[Set[RepoResult], Set[RepoRe
         except pygithub.RateLimitExceededException:
             core_rate_limit_reset = GH_INTERFACE.get_rate_limit().core.reset
             sleep_time = core_rate_limit_reset - datetime.datetime.utcnow()
-            logging.warning("Rate Limit will reset at: %s", core_rate_limit_reset)
-            time.sleep(sleep_time.seconds)
+            logging.warning(
+                "now=%s utcnow=%s", datetime.datetime.now(), datetime.datetime.utcnow()
+            )
+            logging.warning(
+                "Rate Limit will reset at: %s, sleeping %s",
+                core_rate_limit_reset,
+                sleep_time,
+            )
+            sleep_seconds = sleep_time.total_seconds() + 60
+            if sleep_seconds > 3600:
+                sleep_seconds = 3600
+                print("limiting sleep time to 3600 seconds")
+            time.sleep(sleep_seconds)
             continue
         except pygithub.GithubException:
             # Secrets may not be available or error occurred - just skip

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -917,8 +917,21 @@ class LibraryValidator:
             except pygithub.RateLimitExceededException:
                 core_rate_limit_reset = GH_INTERFACE.get_rate_limit().core.reset
                 sleep_time = core_rate_limit_reset - datetime.datetime.utcnow()
-                logging.warning("Rate Limit will reset at: %s", core_rate_limit_reset)
-                time.sleep(sleep_time.seconds)
+                logging.warning(
+                    "Rate Limit will reset at: %s, sleeping %s",
+                    core_rate_limit_reset,
+                    sleep_time,
+                )
+                logging.warning(
+                    "now=%s utcnow=%s",
+                    datetime.datetime.now(),
+                    datetime.datetime.utcnow(),
+                )
+                sleep_seconds = sleep_time.total_seconds() + 60
+                if sleep_seconds > 3600:
+                    sleep_seconds = 3600
+                    print("limiting sleep time to 3600 seconds")
+                time.sleep(sleep_seconds)
                 continue
             except pygithub.GithubException:
                 errors.append(ERROR_RTD_FAILED_TO_LOAD_BUILD_STATUS_GH_NONLIMITED)
@@ -1276,8 +1289,21 @@ class LibraryValidator:
             except pygithub.RateLimitExceededException:
                 core_rate_limit_reset = GH_INTERFACE.get_rate_limit().core.reset
                 sleep_time = core_rate_limit_reset - datetime.datetime.utcnow()
-                logging.warning("Rate Limit will reset at: %s", core_rate_limit_reset)
-                time.sleep(sleep_time.seconds)
+                logging.warning(
+                    "now=%s utcnow=%s",
+                    datetime.datetime.now(),
+                    datetime.datetime.utcnow(),
+                )
+                logging.warning(
+                    "Rate Limit will reset at: %s, sleeping %s + skew",
+                    core_rate_limit_reset,
+                    sleep_time,
+                )
+                sleep_seconds = sleep_time.total_seconds() + 60
+                if sleep_seconds > 3600:
+                    sleep_seconds = 3600
+                    print("limiting sleep time to 3600 seconds")
+                time.sleep(sleep_seconds)
 
     def validate_default_branch(self, repo):
         """Makes sure that the default branch is main"""


### PR DESCRIPTION
The latest failed result had [long lines are truncated]
```
2023-11-29T10:04:45.5181350Z GET /repos/adafruit/Adafruit_CircuitPython_ESP32SPI
2023-11-29T10:04:45.5182341Z 1 requests remaining this hour
2023-11-29T10:04:45.5183097Z GitHub API Rate Limit reached. Pausing until Rate L
2023-11-29T10:04:45.5183863Z Rate Limit will reset at: 2023-11-29 10:21:42
2023-11-29T10:04:45.5184590Z Sleeping 1016 seconds
2023-11-29T10:21:42.6205338Z Resetting dropped connection: api.github.com
2023-11-29T10:21:42.8508270Z https://api.github.com:443 "GET /repos/adafruit/Ada
2023-11-29T10:21:42.8564161Z GET https://api.github.com/repos/adafruit/Adafruit_
2023-11-29T10:21:42.8953319Z https://api.github.com:443 "GET /repos/adafruit/Ada
2023-11-29T10:21:42.8970216Z GET https://api.github.com/repos/adafruit/Adafruit_
2023-11-29T10:21:42.9467791Z https://api.github.com:443 "GET /rate_limit HTTP/1.
2023-11-29T10:21:42.9481187Z GET https://api.github.com/rate_limit {'Authorizati
2023-11-29T10:21:42.9490403Z Rate Limit will reset at: 2023-11-29 10:21:42
2023-11-29T15:21:15.6703237Z ##[error]The operation was canceled.
```

the first message is from our own lib `github_requests.py` because it says "1 requests remaining this hour". However, apparently it didn't wait long enough, because the very next request was still rate-limited. This request was via GH_INTERFACE, and the sleep was SUPPOSED to be corrected by my previous change to do arithmetic between the `core.reset` datetime and a `datetime.utcnow` timestamp.

Multi-pronged approach:
 * Add 60s to all rate limit sleeps to avoid double rate limiting (allows clock skew between github actions server & github API server)
 * limit all rate limit sleeps to no more than 3600 seconds to avoid multi-hour hangs (corrects for bad time arithmetic)
 * print the rate limit time, the "now" time, and the "utcnow" time to diagnose what times and timestamps are involved