### PR TITLE
fix release notes links. Add diff link

### DIFF
--- a/adabot/__init__.py
+++ b/adabot/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2023 Tim Cocks
+#
+# SPDX-License-Identifier: MIT
+
+"""AdaBot is a friendly helper bot that works across the web to make people's
+lives better."""
+
+REQUESTS_TIMEOUT = 30

--- a/adabot/arduino_libraries.py
+++ b/adabot/arduino_libraries.py
@@ -86,7 +86,8 @@ def is_arduino_library(repo):
         + repo["name"]
         + "/"
         + repo["default_branch"]
-        + "/library.properties"
+        + "/library.properties",
+        timeout=30,
     )
     return lib_prop_file.ok
 
@@ -116,7 +117,8 @@ def validate_library_properties(repo):
         + repo["name"]
         + "/"
         + repo["default_branch"]
-        + "/library.properties"
+        + "/library.properties",
+        timeout=30,
     )
     if not lib_prop_file.ok:
         # print("{} skipped".format(repo["name"]))
@@ -193,7 +195,8 @@ def validate_actions(repo):
         + repo["name"]
         + "/"
         + repo["default_branch"]
-        + "/.github/workflows/githubci.yml"
+        + "/.github/workflows/githubci.yml",
+        timeout=30,
     )
     return repo_has_actions.ok
 
@@ -309,7 +312,9 @@ def main(verbosity=1, output_file=None):  # pylint: disable=missing-function-doc
         logger.setLevel("CRITICAL")
 
     try:
-        reply = requests.get("http://downloads.arduino.cc/libraries/library_index.json")
+        reply = requests.get(
+            "http://downloads.arduino.cc/libraries/library_index.json", timeout=30
+        )
         if not reply.ok:
             logging.error(
                 "Could not fetch http://downloads.arduino.cc/libraries/library_index.json"

--- a/adabot/arduino_libraries.py
+++ b/adabot/arduino_libraries.py
@@ -11,7 +11,7 @@ import traceback
 
 import requests
 
-from adabot import github_requests as gh_reqs
+from adabot import github_requests as gh_reqs, REQUESTS_TIMEOUT
 
 logger = logging.getLogger(__name__)
 ch = logging.StreamHandler(stream=sys.stdout)
@@ -87,7 +87,7 @@ def is_arduino_library(repo):
         + "/"
         + repo["default_branch"]
         + "/library.properties",
-        timeout=30,
+        timeout=REQUESTS_TIMEOUT,
     )
     return lib_prop_file.ok
 
@@ -118,7 +118,7 @@ def validate_library_properties(repo):
         + "/"
         + repo["default_branch"]
         + "/library.properties",
-        timeout=30,
+        timeout=REQUESTS_TIMEOUT,
     )
     if not lib_prop_file.ok:
         # print("{} skipped".format(repo["name"]))
@@ -196,7 +196,7 @@ def validate_actions(repo):
         + "/"
         + repo["default_branch"]
         + "/.github/workflows/githubci.yml",
-        timeout=30,
+        timeout=REQUESTS_TIMEOUT,
     )
     return repo_has_actions.ok
 
@@ -313,7 +313,8 @@ def main(verbosity=1, output_file=None):  # pylint: disable=missing-function-doc
 
     try:
         reply = requests.get(
-            "http://downloads.arduino.cc/libraries/library_index.json", timeout=30
+            "http://downloads.arduino.cc/libraries/library_index.json",
+            timeout=REQUESTS_TIMEOUT,
         )
         if not reply.ok:
             logging.error(

--- a/adabot/circuitpython_library_download_stats.py
+++ b/adabot/circuitpython_library_download_stats.py
@@ -17,7 +17,7 @@ import requests
 from google.cloud import bigquery
 import google.oauth2.service_account
 
-from adabot import github_requests as gh_reqs
+from adabot import github_requests as gh_reqs, REQUESTS_TIMEOUT
 from adabot.lib import common_funcs
 
 # Setup ArgumentParser
@@ -60,7 +60,7 @@ PIWHEELS_PACKAGES_URL = "https://www.piwheels.org/packages.json"
 def retrieve_piwheels_stats():
     """Get data dump of piwheels download stats"""
     stats = {}
-    response = requests.get(PIWHEELS_PACKAGES_URL, timeout=30)
+    response = requests.get(PIWHEELS_PACKAGES_URL, timeout=REQUESTS_TIMEOUT)
     if response.ok:
         packages = response.json()
         stats = {

--- a/adabot/circuitpython_library_download_stats.py
+++ b/adabot/circuitpython_library_download_stats.py
@@ -60,7 +60,7 @@ PIWHEELS_PACKAGES_URL = "https://www.piwheels.org/packages.json"
 def retrieve_piwheels_stats():
     """Get data dump of piwheels download stats"""
     stats = {}
-    response = requests.get(PIWHEELS_PACKAGES_URL)
+    response = requests.get(PIWHEELS_PACKAGES_URL, timeout=30)
     if response.ok:
         packages = response.json()
         stats = {

--- a/adabot/lib/assign_hacktober_label.py
+++ b/adabot/lib/assign_hacktober_label.py
@@ -11,7 +11,7 @@ import argparse
 import datetime
 import requests
 
-from adabot import github_requests as gh_reqs
+from adabot import github_requests as gh_reqs, REQUESTS_TIMEOUT
 from adabot.lib import common_funcs
 
 cli_args = argparse.ArgumentParser(description="Hacktoberfest Label Assigner")
@@ -73,7 +73,9 @@ def get_open_issues(repo):
         )
 
         if response.links.get("next"):
-            response = requests.get(response.links["next"]["url"], timeout=30)
+            response = requests.get(
+                response.links["next"]["url"], timeout=REQUESTS_TIMEOUT
+            )
         else:
             break
 

--- a/adabot/lib/assign_hacktober_label.py
+++ b/adabot/lib/assign_hacktober_label.py
@@ -73,7 +73,7 @@ def get_open_issues(repo):
         )
 
         if response.links.get("next"):
-            response = requests.get(response.links["next"]["url"])
+            response = requests.get(response.links["next"]["url"], timeout=30)
         else:
             break
 

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -21,7 +21,7 @@ import yaml
 import parse
 
 import github as pygithub
-from adabot import github_requests as gh_reqs
+from adabot import github_requests as gh_reqs, REQUESTS_TIMEOUT
 from adabot.lib import common_funcs
 from adabot.lib import assign_hacktober_label as hacktober
 
@@ -231,7 +231,7 @@ class LibraryValidator:
                 "%20if%20cookiecutter.sphinx_docs%20in%20%5B'y'%2C%20'yes'%5D%20%25"
                 "%7D.readthedocs.yaml%7B%25%20endif%20%25%7D"
             )
-            rtd_yml = requests.get(rtd_yml_dl_url, timeout=30)
+            rtd_yml = requests.get(rtd_yml_dl_url, timeout=REQUESTS_TIMEOUT)
             if rtd_yml.ok:
                 try:
                     self._rtd_yaml_base = yaml.safe_load(rtd_yml.text)
@@ -255,7 +255,7 @@ class LibraryValidator:
                 "circuitpython/main/%7B%7B%20cookiecutter.__dirname%20%7D%7D/.pre-"
                 "commit-config.yaml"
             )
-            pcc_yml = requests.get(pcc_yml_dl_url, timeout=30)
+            pcc_yml = requests.get(pcc_yml_dl_url, timeout=REQUESTS_TIMEOUT)
             if pcc_yml.ok:
                 try:
                     pcc_yaml_base = yaml.safe_load(pcc_yml.text)
@@ -464,7 +464,7 @@ class LibraryValidator:
     def _validate_readme(self, download_url):
         # We use requests because file contents are hosted by
         # githubusercontent.com, not the API domain.
-        contents = requests.get(download_url, timeout=30)
+        contents = requests.get(download_url, timeout=REQUESTS_TIMEOUT)
         if not contents.ok:
             return [ERROR_README_DOWNLOAD_FAILED]
 
@@ -510,7 +510,7 @@ class LibraryValidator:
         """
         # We use requests because file contents are hosted by
         # githubusercontent.com, not the API domain.
-        contents = requests.get(download_url, timeout=30)
+        contents = requests.get(download_url, timeout=REQUESTS_TIMEOUT)
         if not contents.ok:
             return [ERROR_PYFILE_DOWNLOAD_FAILED]
 
@@ -548,7 +548,7 @@ class LibraryValidator:
         """
 
         download_url = actions_build_info["download_url"]
-        contents = requests.get(download_url, timeout=30)
+        contents = requests.get(download_url, timeout=REQUESTS_TIMEOUT)
         if not contents.ok:
             return [ERROR_PYFILE_DOWNLOAD_FAILED]
 
@@ -558,7 +558,7 @@ class LibraryValidator:
 
     def _validate_pre_commit_config_yaml(self, file_info):
         download_url = file_info["download_url"]
-        contents = requests.get(download_url, timeout=30)
+        contents = requests.get(download_url, timeout=REQUESTS_TIMEOUT)
         if not contents.ok:
             return [ERROR_PYFILE_DOWNLOAD_FAILED]
 
@@ -595,7 +595,7 @@ class LibraryValidator:
     def _validate_pyproject_toml(self, file_info):
         """Check pyproject.toml for pypi compatibility"""
         download_url = file_info["download_url"]
-        contents = requests.get(download_url, timeout=30)
+        contents = requests.get(download_url, timeout=REQUESTS_TIMEOUT)
         if not contents.ok:
             return [ERROR_TOMLFILE_DOWNLOAD_FAILED]
         return []
@@ -603,7 +603,7 @@ class LibraryValidator:
     def _validate_requirements_txt(self, repo, file_info, check_blinka=True):
         """Check requirements.txt for pypi compatibility"""
         download_url = file_info["download_url"]
-        contents = requests.get(download_url, timeout=30)
+        contents = requests.get(download_url, timeout=REQUESTS_TIMEOUT)
         if not contents.ok:
             return [ERROR_PYFILE_DOWNLOAD_FAILED]
 
@@ -718,7 +718,9 @@ class LibraryValidator:
                 if ".readthedocs.yaml" in files:
                     filename = ".readthedocs.yaml"
                 file_info = content_list[files.index(filename)]
-                rtd_contents = requests.get(file_info["download_url"], timeout=30)
+                rtd_contents = requests.get(
+                    file_info["download_url"], timeout=REQUESTS_TIMEOUT
+                )
                 if rtd_contents.ok:
                     try:
                         rtd_yml = yaml.safe_load(rtd_contents.text)
@@ -736,7 +738,9 @@ class LibraryValidator:
             if len(self._pcc_versions) or self.pcc_versions != "":
                 filename = ".pre-commit-config.yaml"
                 file_info = content_list[files.index(filename)]
-                pcc_contents = requests.get(file_info["download_url"], timeout=30)
+                pcc_contents = requests.get(
+                    file_info["download_url"], timeout=REQUESTS_TIMEOUT
+                )
                 if pcc_contents.ok:
                     try:
                         pcc_yml = yaml.safe_load(pcc_contents.text)
@@ -938,7 +942,7 @@ class LibraryValidator:
             url = f"https://readthedocs.org/api/v3/projects/{rtd_slug}/builds/"
             rtd_token = os.environ["RTD_TOKEN"]
             headers = {"Authorization": f"token {rtd_token}"}
-            response = requests.get(url, headers=headers, timeout=30)
+            response = requests.get(url, headers=headers, timeout=REQUESTS_TIMEOUT)
             json_response = response.json()
 
             error_message = json_response.get("detail")

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -231,7 +231,7 @@ class LibraryValidator:
                 "%20if%20cookiecutter.sphinx_docs%20in%20%5B'y'%2C%20'yes'%5D%20%25"
                 "%7D.readthedocs.yaml%7B%25%20endif%20%25%7D"
             )
-            rtd_yml = requests.get(rtd_yml_dl_url)
+            rtd_yml = requests.get(rtd_yml_dl_url, timeout=30)
             if rtd_yml.ok:
                 try:
                     self._rtd_yaml_base = yaml.safe_load(rtd_yml.text)
@@ -255,7 +255,7 @@ class LibraryValidator:
                 "circuitpython/main/%7B%7B%20cookiecutter.__dirname%20%7D%7D/.pre-"
                 "commit-config.yaml"
             )
-            pcc_yml = requests.get(pcc_yml_dl_url)
+            pcc_yml = requests.get(pcc_yml_dl_url, timeout=30)
             if pcc_yml.ok:
                 try:
                     pcc_yaml_base = yaml.safe_load(pcc_yml.text)
@@ -718,7 +718,7 @@ class LibraryValidator:
                 if ".readthedocs.yaml" in files:
                     filename = ".readthedocs.yaml"
                 file_info = content_list[files.index(filename)]
-                rtd_contents = requests.get(file_info["download_url"])
+                rtd_contents = requests.get(file_info["download_url"], timeout=30)
                 if rtd_contents.ok:
                     try:
                         rtd_yml = yaml.safe_load(rtd_contents.text)
@@ -736,7 +736,7 @@ class LibraryValidator:
             if len(self._pcc_versions) or self.pcc_versions != "":
                 filename = ".pre-commit-config.yaml"
                 file_info = content_list[files.index(filename)]
-                pcc_contents = requests.get(file_info["download_url"])
+                pcc_contents = requests.get(file_info["download_url"], timeout=30)
                 if pcc_contents.ok:
                     try:
                         pcc_yml = yaml.safe_load(pcc_contents.text)
@@ -938,7 +938,7 @@ class LibraryValidator:
             url = f"https://readthedocs.org/api/v3/projects/{rtd_slug}/builds/"
             rtd_token = os.environ["RTD_TOKEN"]
             headers = {"Authorization": f"token {rtd_token}"}
-            response = requests.get(url, headers=headers)
+            response = requests.get(url, headers=headers, timeout=30)
             json_response = response.json()
 
             error_message = json_response.get("detail")

--- a/adabot/pypi_requests.py
+++ b/adabot/pypi_requests.py
@@ -9,6 +9,8 @@
 
 import requests
 
+from adabot import REQUESTS_TIMEOUT
+
 
 def _fix_url(url):
     if url.startswith("/"):
@@ -18,4 +20,4 @@ def _fix_url(url):
 
 def get(url, **kwargs):
     """Process a GET request from pypi.org"""
-    return requests.get(_fix_url(url), timeout=30, **kwargs)
+    return requests.get(_fix_url(url), timeout=REQUESTS_TIMEOUT, **kwargs)

--- a/tools/docs_status.py
+++ b/tools/docs_status.py
@@ -64,7 +64,7 @@ def check_docs_status(
     # GET the latest documentation build runs
     url = f"https://readthedocs.org/api/v3/projects/{rtd_slug}/builds/"
     headers = {"Authorization": f"token {rtd_token}"}
-    response = requests.get(url, headers=headers)
+    response = requests.get(url, headers=headers, timeout=30)
     json_response: dict[str, Any] = response.json()
 
     # Return the results of the latest run

--- a/tools/docs_status.py
+++ b/tools/docs_status.py
@@ -21,10 +21,12 @@ import parse
 import requests
 from github.Repository import Repository
 from github.ContentFile import ContentFile
+
 from iterate_libraries import (
     iter_remote_bundle_with_func,
     RemoteLibFunc_IterResult,
 )
+from adabot import REQUESTS_TIMEOUT
 
 
 def check_docs_status(
@@ -64,7 +66,7 @@ def check_docs_status(
     # GET the latest documentation build runs
     url = f"https://readthedocs.org/api/v3/projects/{rtd_slug}/builds/"
     headers = {"Authorization": f"token {rtd_token}"}
-    response = requests.get(url, headers=headers, timeout=30)
+    response = requests.get(url, headers=headers, timeout=REQUESTS_TIMEOUT)
     json_response: dict[str, Any] = response.json()
 
     # Return the results of the latest run

--- a/tools/file_compare.py
+++ b/tools/file_compare.py
@@ -54,9 +54,9 @@ def compare(git_file: str, token: Optional[str] = None) -> list:
             headers = CaseInsensitiveDict()
             headers["Authorization"] = f"token {token}"
 
-            resp = requests.get(url, headers=headers)
+            resp = requests.get(url, headers=headers, timeout=30)
         else:
-            resp = requests.get(url)
+            resp = requests.get(url, timeout=30)
 
         if resp.status_code != 200:
             print(name)

--- a/tools/file_compare.py
+++ b/tools/file_compare.py
@@ -20,6 +20,7 @@ from typing import Optional
 import requests
 from requests.structures import CaseInsensitiveDict
 
+from adabot import REQUESTS_TIMEOUT
 from adabot.lib.common_funcs import list_repos
 
 
@@ -54,9 +55,9 @@ def compare(git_file: str, token: Optional[str] = None) -> list:
             headers = CaseInsensitiveDict()
             headers["Authorization"] = f"token {token}"
 
-            resp = requests.get(url, headers=headers, timeout=30)
+            resp = requests.get(url, headers=headers, timeout=REQUESTS_TIMEOUT)
         else:
-            resp = requests.get(url, timeout=30)
+            resp = requests.get(url, timeout=REQUESTS_TIMEOUT)
 
         if resp.status_code != 200:
             print(name)

--- a/tools/find_text.py
+++ b/tools/find_text.py
@@ -129,7 +129,7 @@ print(f"Repos found: {len(all_repos)}")
 
 for repo in all_repos:
     INFO = "getting {} for: {}".format(FILE, repo["name"])
-    response = requests.get(URL_TEMPLATE.format(repo["name"], FILE))
+    response = requests.get(URL_TEMPLATE.format(repo["name"], FILE), timeout=30)
     result = []
     if response.status_code == 404:
         RESULTS["file_not_found"].append(repo["html_url"])

--- a/tools/find_text.py
+++ b/tools/find_text.py
@@ -19,6 +19,7 @@ import sys
 
 import requests
 
+from adabot import REQUESTS_TIMEOUT
 from adabot.lib.common_funcs import list_repos
 
 argumentList = sys.argv[1:]
@@ -129,7 +130,9 @@ print(f"Repos found: {len(all_repos)}")
 
 for repo in all_repos:
     INFO = "getting {} for: {}".format(FILE, repo["name"])
-    response = requests.get(URL_TEMPLATE.format(repo["name"], FILE), timeout=30)
+    response = requests.get(
+        URL_TEMPLATE.format(repo["name"], FILE), timeout=REQUESTS_TIMEOUT
+    )
     result = []
     if response.status_code == 404:
         RESULTS["file_not_found"].append(repo["html_url"])


### PR DESCRIPTION
While using the new release automation I came across a few things in need of tweaking.

This change covers three main things:

- fix the pip installation command in the release notes. It was previously incorrectly using the full shorthand library name which will not work with pip install it must have `adafruit-circuitpython-` preceding the library name. To solve this I changed the function to accept the shorthand name and then used that to create the pypi name and docs URL from it.
- Remove an errant "main" chunk of code that was leftover from development. Prior to my other changes this had gone unnoticed because it didn't cause any trouble.
- added the Github 'changes' link to the release notes that are posted. The link got printed into the terminal of the person running the release automation this makes it so that effectively the same link is put into the release notes.