### PR TITLE
Use newer pylint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/pylint
-    rev: v2.17.4
+    rev: v3.2.6
     hooks:
     -   id: pylint
         name: pylint

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -424,8 +424,7 @@ class LibraryValidator:
                         commit_date = datetime.datetime.strptime(
                             commit_date_val, "%Y-%m-%dT%H:%M:%SZ"
                         )
-                        if commit_date < oldest_commit_date:
-                            oldest_commit_date = commit_date
+                        oldest_commit_date = min(oldest_commit_date, commit_date)
 
                     date_diff = datetime.datetime.today() - oldest_commit_date
                     if date_diff.days > datetime.date.today().max.day:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 
 black==24.3.0
 packaging==22.0
-pylint==2.11.1
+pylint==3.2.6
 pytest
 pyyaml>=5.4.1
 redis==4.5.4

--- a/tools/ci_status.py
+++ b/tools/ci_status.py
@@ -81,6 +81,7 @@ def run_gh_rest_rerun(
     """
     if not rerun_level:
         return False
+    result = None
     if rerun_level == 1:
         result = (
             run_gh_rest_check(lib_repo, user, branch, workflow_filename) == "success"


### PR DESCRIPTION
While looking into an issue with a generated report I had trouble getting adabots requirements installed locally in python 3.12. Updating the version of pylint to a newer one allows it to work under py3.12.  The version of pylint that pre-commit uses is specified separately and also has been updated. 

The other changes are to resolve the 2 pylint issues that get flagged by the newer version.