### PR TITLE
strip lib string before parse

### DIFF
--- a/adabot/lib/bundle_announcer.py
+++ b/adabot/lib/bundle_announcer.py
@@ -65,7 +65,7 @@ def get_bundle_updates(full_repo_name: str) -> Tuple[Set[RepoResult], Set[RepoRe
                         x.strip(",") for x in relevant_line.split(" ")[2:]
                     ]
                     for lib in lib_components:
-                        comps = parse.parse("[{name:S}]({link_comp:S})", lib)
+                        comps = parse.parse("[{name:S}]({link_comp:S})", lib.strip())
                         link: str = parse.search(
                             "{link:S}/releases", comps["link_comp"]
                         )["link"]


### PR DESCRIPTION
For some reason some of the lib strings have a `\r` at the end of them i.e. 
```
"[ticks](https://github.com/adafruit/Adafruit_CircuitPython_Ticks/releases/1.1.0)\r"
```
That causes `parse.parse()` to return `None` instead of the matched variables. Which then raises an exception 2 lines later when an attempt to access `comps["link_comp"]`.

This resolves it by calling `.strip()` prior to `parse()` so that the string value will match the pattern that parse is expecting.

I tested it successfully by running `python3 -m adabot.circuitpython_libraries` with the appropriate env variables set up.