### PR TITLE
Test bundle builds job before push

### DIFF
--- a/.github/workflows/bundle_cron.yml
+++ b/.github/workflows/bundle_cron.yml
@@ -20,8 +20,37 @@ jobs:
         run: |
           echo "This workflow will only run if Adafruit is the repository owner."
           echo "Repository owner is Adafruit: $OWNER_IS_ADAFRUIT"
+  test-bundle-builds:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.12
+      - name: Versions
+        run: |
+          python3 --version
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Install deps
+        run: |
+          pip install -r requirements.txt
+      - name: Test Building Community Bundle
+        run: |
+          git clone --recurse-submodules https://github.com/adafruit/CircuitPython_Community_Bundle.git
+          cd CircuitPython_Community_Bundle
+          circuitpython-build-bundles --filename_prefix test-community-bundle --library_location libraries --library_depth 2
+      - name: Test Building Adafruit Bundle
+        run: |
+          git clone --recurse-submodules https://github.com/adafruit/Adafruit_CircuitPython_Bundle.git
+          cd Adafruit_CircuitPython_Bundle
+          circuitpython-build-bundles --filename_prefix test-adafruit-bundle --library_location libraries --library_depth 2
+
   update-bundles:
     runs-on: ubuntu-latest
+    # Only run if test-bundle-builds succeeds
+    needs: test-bundle-builds
     # Only run the build on Adafruit's repository. Forks won't have the secrets.
     # Its necessary to do this here, since 'schedule' events cannot (currently)
     # be limited (they run on all forks' default branches).

--- a/.github/workflows/bundle_cron.yml
+++ b/.github/workflows/bundle_cron.yml
@@ -7,6 +7,7 @@ name: Update Bundles
 on:
   schedule:
     - cron: 0 5 * * *
+  workflow_dispatch:
 
 jobs:
   check-repo-owner:
@@ -20,52 +21,22 @@ jobs:
         run: |
           echo "This workflow will only run if Adafruit is the repository owner."
           echo "Repository owner is Adafruit: $OWNER_IS_ADAFRUIT"
-  test-bundle-builds:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.12
-      - name: Versions
-        run: |
-          python3 --version
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-      - name: Install deps
-        run: |
-          pip install -r requirements.txt
-      - name: Test Building Community Bundle
-        run: |
-          git clone --recurse-submodules https://github.com/adafruit/CircuitPython_Community_Bundle.git
-          cd CircuitPython_Community_Bundle
-          circuitpython-build-bundles --filename_prefix test-community-bundle --library_location libraries --library_depth 2
-      - name: Test Building Adafruit Bundle
-        run: |
-          git clone --recurse-submodules https://github.com/adafruit/Adafruit_CircuitPython_Bundle.git
-          cd Adafruit_CircuitPython_Bundle
-          circuitpython-build-bundles --filename_prefix test-adafruit-bundle --library_location libraries --library_depth 2
-
   update-bundles:
     runs-on: ubuntu-latest
-    # Only run if test-bundle-builds succeeds
-    needs: test-bundle-builds
     # Only run the build on Adafruit's repository. Forks won't have the secrets.
     # Its necessary to do this here, since 'schedule' events cannot (currently)
     # be limited (they run on all forks' default branches).
     if: startswith(github.repository, 'adafruit/')
-    services:
-      redis:
-        image: redis
-        ports:
-          - 6379/tcp
-        options: --entrypoint redis-server
     steps:
-    - name: Set up Python 3.9
+    - name: Set up Python 3.12
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.12
+    - name: Load contributor cache
+      uses: actions/cache@v4
+      with:
+        key: "contributor-cache"
+        path: "contributors.json"
     - name: Versions
       run: |
         python3 --version
@@ -80,7 +51,6 @@ jobs:
         ADABOT_EMAIL: ${{ secrets.ADABOT_EMAIL }}
         ADABOT_GITHUB_USER: ${{ secrets.ADABOT_GITHUB_USER }}
         ADABOT_GITHUB_ACCESS_TOKEN: ${{ secrets.ADABOT_GITHUB_ACCESS_TOKEN }}
-        REDIS_PORT: ${{ job.services.redis.ports[6379] }}
         BIGQUERY_PRIVATE_KEY: ${{ secrets.BIGQUERY_PRIVATE_KEY }}
         BIGQUERY_CLIENT_EMAIL: ${{ secrets.BIGQUERY_CLIENT_EMAIL }}
       run: |

--- a/adabot/circuitpython_bundle.py
+++ b/adabot/circuitpython_bundle.py
@@ -6,29 +6,27 @@
     If updates are found the bundle is updated, updates are pushed to the
     remote, and a new release is made.
 """
-
+import contextlib
 from datetime import date
 from io import StringIO
+import json
 import os
+import pathlib
 import shlex
 import subprocess
 
-import redis as redis_py
-
 import sh
+from circuitpython_build_tools.scripts.build_bundles import build_bundles
 from sh.contrib import git
 
 from adabot import github_requests as gh_reqs
 from adabot.lib import common_funcs
 from adabot import circuitpython_library_download_stats as dl_stats
 
-REDIS = None
-if "GITHUB_WORKSPACE" in os.environ:
-    REDIS = redis_py.StrictRedis(port=os.environ["REDIS_PORT"])
-else:
-    REDIS = redis_py.StrictRedis()
 
 BUNDLES = ["Adafruit_CircuitPython_Bundle", "CircuitPython_Community_Bundle"]
+
+CONTRIBUTOR_CACHE = {}
 
 
 def fetch_bundle(bundle, bundle_path):
@@ -380,20 +378,17 @@ def get_contributors(repo, commit_range):
         return contributors
     for log_line in output.split("\n"):
         sha, author_email, committer_email = log_line.split(",")
-        author = REDIS.get("github_username:" + author_email)
-        committer = REDIS.get("github_username:" + committer_email)
+        author = CONTRIBUTOR_CACHE.get("github_username:" + author_email, None)
+        committer = CONTRIBUTOR_CACHE.get("github_username:" + committer_email, None)
         if not author or not committer:
             github_commit_info = gh_reqs.get("/repos/" + repo + "/commits/" + sha)
             github_commit_info = github_commit_info.json()
             if github_commit_info["author"]:
                 author = github_commit_info["author"]["login"]
-                REDIS.set("github_username:" + author_email, author)
+                CONTRIBUTOR_CACHE["github_username:" + author_email] = author
             if github_commit_info["committer"]:
                 committer = github_commit_info["committer"]["login"]
-                REDIS.set("github_username:" + committer_email, committer)
-        else:
-            author = author.decode("utf-8")
-            committer = committer.decode("utf-8")
+                CONTRIBUTOR_CACHE["github_username:" + committer_email] = committer
 
         if committer_email == "noreply@github.com":
             committer = None
@@ -423,6 +418,26 @@ def add_contributors(master_list, additions):
         if contributor not in master_list:
             master_list[contributor] = 0
         master_list[contributor] += additions[contributor]
+
+
+def test_bundle_build(bundle_dir):
+    """
+    Attempts to build the bundle at the given location.
+    Returns exit code 0 if success.
+    Returns exit code >0 if failed to build.
+    """
+    with contextlib.chdir(bundle_dir):
+        build_bundles(
+            [
+                "--filename_prefix",
+                "test-build-bundle",
+                "--library_location",
+                "libraries",
+                "--library_depth",
+                "2",
+            ],
+            standalone_mode=False,
+        )
 
 
 # pylint: disable=too-many-locals,too-many-branches,too-many-statements
@@ -506,7 +521,7 @@ def new_release(bundle, bundle_path):
     release_description.append(
         "The libraries in each release are compiled for all recent major versions of CircuitPython."
         " Please download the one that matches the major version of your CircuitPython. For example"
-        ", if you are running 8.2.6 you should download the `8.x` bundle.\n"
+        ", if you are running 9.1.1 you should download the `9.x` bundle.\n"
     )
 
     release_description.append(
@@ -554,6 +569,10 @@ def new_release(bundle, bundle_path):
 
 
 if __name__ == "__main__":
+    contributor_cache_fn = pathlib.Path("contributors.json").resolve()
+    if contributor_cache_fn.exists():
+        CONTRIBUTOR_CACHE = json.loads(contributor_cache_fn.read_text())
+
     bundles_dir = os.path.abspath(".bundles")
     if "GITHUB_WORKSPACE" in os.environ:
         git.config("--global", "user.name", "adabot")
@@ -563,6 +582,13 @@ if __name__ == "__main__":
         try:
             fetch_bundle(cp_bundle, bundle_dir)
             updates, release_required = update_bundle(bundle_dir)
+
+            # test bundle build and stop if it does not succeed
+            try:
+                test_bundle_build(bundle_dir)
+            except SystemExit as e:
+                if e.code != 0:
+                    raise RuntimeError("Test Build of Bundle Failed") from e
             if release_required:
                 commit_updates(bundle_dir, updates)
                 push_updates(bundle_dir)
@@ -570,3 +596,6 @@ if __name__ == "__main__":
         except RuntimeError as e:
             print("Failed to update and release:", cp_bundle)
             print(e)
+            raise e
+        finally:
+            contributor_cache_fn.write_text(json.dumps(CONTRIBUTOR_CACHE))

--- a/adabot/circuitpython_bundle.py
+++ b/adabot/circuitpython_bundle.py
@@ -423,8 +423,8 @@ def add_contributors(master_list, additions):
 def test_bundle_build(bundle_dir):
     """
     Attempts to build the bundle at the given location.
-    Returns exit code 0 if success.
-    Returns exit code >0 if failed to build.
+    Raises system exit status 0 if successful.
+    Raises system exit status >0 if failed to build.
     """
     with contextlib.chdir(bundle_dir):
         build_bundles(

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 black==24.3.0
+circuitpython-build-tools
 packaging==22.0
 pylint==3.2.6
 pytest


### PR DESCRIPTION
Resolves: #377

This adds a new job to the bundle cron action which builds both the community and adafruit bundles. 

The `update-bundles` job has had `needs: test-bundle-builds` added to it so that it depends upon the prior test builds job. If that test build fails then update-bundles will be skipped. 

I tested this to the best of my abilities in a test repo. There are a few failed runs visible here: https://github.com/FoamyGuy/adabot_actions_tests/actions which validated the way that `needs` will skip the job if it's dependency failed. For testing I modified the task to add an erroneous extra file into one of the libraries similarly to what caused the recent build failures.

That being said, I'm not sure if there is a great way to test it within the cron task context without just merging it and checking in after the next time it runs. And if there is a desire to test the failure case we'd need to temporarily modify the test build action to make one or both of the builds fail. If anyone does know of a better way to test I'm happy to give it a try. 
