### PR TITLE
Fix update bundles

### DIFF
--- a/.github/workflows/bundle_cron.yml
+++ b/.github/workflows/bundle_cron.yml
@@ -7,6 +7,7 @@ name: Update Bundles
 on:
   schedule:
     - cron: 0 5 * * *
+  workflow_dispatch:
 
 jobs:
   check-repo-owner:
@@ -50,7 +51,6 @@ jobs:
         ADABOT_EMAIL: ${{ secrets.ADABOT_EMAIL }}
         ADABOT_GITHUB_USER: ${{ secrets.ADABOT_GITHUB_USER }}
         ADABOT_GITHUB_ACCESS_TOKEN: ${{ secrets.ADABOT_GITHUB_ACCESS_TOKEN }}
-        REDIS_PORT: ${{ job.services.redis.ports[6379] }}
         BIGQUERY_PRIVATE_KEY: ${{ secrets.BIGQUERY_PRIVATE_KEY }}
         BIGQUERY_CLIENT_EMAIL: ${{ secrets.BIGQUERY_CLIENT_EMAIL }}
       run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,10 +10,10 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Python 3.9
+    - name: Set up Python 3
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3
     - name: Versions
       run: |
         python3 --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,17 +24,11 @@ jobs:
     # Its necessary to do this here, since 'schedule' events cannot (currently)
     # be limited (they run on all forks' default branches).
     if: startswith(github.repository, 'adafruit/')
-    services:
-      redis:
-        image: redis
-        ports:
-          - 6379/tcp
-        options: --entrypoint redis-server
     steps:
-    - name: Set up Python 3.9
+    - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3
     - name: Versions
       run: |
         python3 --version
@@ -50,6 +44,5 @@ jobs:
         ADABOT_GITHUB_USER: ${{ secrets.ADABOT_GITHUB_USER }}
         ADABOT_GITHUB_ACCESS_TOKEN: ${{ secrets.ADABOT_GITHUB_ACCESS_TOKEN }}
         RTD_TOKEN: ${{ secrets.RTD_TOKEN }}
-        REDIS_PORT: ${{ job.services.redis.ports[6379] }}
       run: |
         python3 -u -m pytest

--- a/adabot/arduino_libraries.py
+++ b/adabot/arduino_libraries.py
@@ -322,8 +322,8 @@ def main(verbosity=1, output_file=None):  # pylint: disable=missing-function-doc
         run_arduino_lib_checks()
     except:
         _, exc_val, exc_tb = sys.exc_info()
-        logger.error("Exception Occurred!", quiet=True)
-        logger.error(("-" * 60), quiet=True)
+        logger.error("Exception Occurred!")
+        logger.error(("-" * 60))
         logger.error("Traceback (most recent call last):")
         trace = traceback.format_tb(exc_tb)
         for line in trace:

--- a/adabot/circuitpython_bundle.py
+++ b/adabot/circuitpython_bundle.py
@@ -25,6 +25,8 @@ from adabot import circuitpython_library_download_stats as dl_stats
 
 BUNDLES = ["Adafruit_CircuitPython_Bundle", "CircuitPython_Community_Bundle"]
 
+CONTRIBUTOR_CACHE = {}
+
 
 def fetch_bundle(bundle, bundle_path):
     """Clones `bundle` to `bundle_path`"""
@@ -549,8 +551,6 @@ if __name__ == "__main__":
     contributor_cache_fn = pathlib.Path("contributors.json").resolve()
     if contributor_cache_fn.exists():
         CONTRIBUTOR_CACHE = json.loads(contributor_cache_fn.read_text())
-    else:
-        CONTRIBUTOR_CACHE = {}
 
     bundles_dir = os.path.abspath(".bundles")
     if "GITHUB_WORKSPACE" in os.environ:

--- a/adabot/github_requests.py
+++ b/adabot/github_requests.py
@@ -64,7 +64,9 @@ def request(method, url, **kwargs):
             _fix_url(url), timeout=TIMEOUT, **_fix_kwargs(kwargs)
         )
         from_cache = getattr(response, "from_cache", False)
-        remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
+        # If rate limit remaining is missing, then assume we're fine. Use a million to signify this
+        # case. GitHub will be in the single thousands.
+        remaining = int(response.headers.get("X-RateLimit-Remaining", 1000000))
         logging.debug(
             "GET %s %s status=%s",
             url,


### PR DESCRIPTION
When the remaining rate limit is missing, we assumed we were out (`0`). This broke later when we tried to wait until we had more requests. Now we'll assume we have remaining requests instead.

Also, update to latest Python and remove more Redis leftovers.