### PR TITLE
added patch to remove deprecated sphinx function call.

### DIFF
--- a/patches/0001-remove-deprecated-get_html_theme_path-call.patch
+++ b/patches/0001-remove-deprecated-get_html_theme_path-call.patch
@@ -1,0 +1,24 @@
+From 7b7cdd3d13f4ee2cf4be44ea3966dfdec659f9a9 Mon Sep 17 00:00:00 2001
+From: foamyguy <foamyguy@gmail.com>
+Date: Mon, 7 Oct 2024 09:24:05 -0500
+Subject: [PATCH] remove deprecated get_html_theme_path() call
+
+---
+ docs/conf.py | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/docs/conf.py b/docs/conf.py
+index de06824..cb73a8f 100644
+--- a/docs/conf.py
++++ b/docs/conf.py
+@@ -109,7 +109,6 @@ napoleon_numpy_docstring = False
+ import sphinx_rtd_theme
+ 
+ html_theme = "sphinx_rtd_theme"
+-html_theme_path = [sphinx_rtd_theme.get_html_theme_path(), "."]
+ 
+ # Add any paths that contain custom static files (such as style sheets) here,
+ # relative to this directory. They are copied after the builtin static files,
+-- 
+2.46.2
+


### PR DESCRIPTION
The newest version of sphinx-rtd-themes has deprecated a function call that was made in our docs/conf.py files which causes the docs build to fail.  Stacktrace can be seen here: https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/actions/runs/11217110767/job/31177912073#step:2:1002

This removes the deprecated function call. The error message indicates that it is safe to remove it if it's being used to set this variable. 

A local docs build inside of Display_Text library was able to build successfully with this change. 