### PR TITLE
patch to remove sphinx function call alternative config file

### DIFF
--- a/patches/0001-remove-deprecated-get_html_theme_path-call-alt-config.patch
+++ b/patches/0001-remove-deprecated-get_html_theme_path-call-alt-config.patch
@@ -1,0 +1,24 @@
+From 164ae12550a34b8751aeef0cb676eae4e72ab610 Mon Sep 17 00:00:00 2001
+From: foamyguy <foamyguy@gmail.com>
+Date: Mon, 7 Oct 2024 14:51:48 -0500
+Subject: [PATCH] remove deprecated sphinx theme call
+
+---
+ docs/conf.py | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/docs/conf.py b/docs/conf.py
+index a393c5e..0d0e89d 100644
+--- a/docs/conf.py
++++ b/docs/conf.py
+@@ -154,7 +154,6 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
+         import sphinx_rtd_theme
+ 
+         html_theme = "sphinx_rtd_theme"
+-        html_theme_path = [sphinx_rtd_theme.get_html_theme_path(), "."]
+     except:
+         html_theme = "default"
+         html_theme_path = ["."]
+-- 
+2.46.2
+


### PR DESCRIPTION
There were 9 repos that have a different variation of the theme configuration in their docs/conf.py file. Here is an example of one of them: https://github.com/adafruit/Adafruit_CircuitPython_AMG88xx/blob/main/docs/conf.py#L152-L162

This patch file should update those 9 with the same fix for sphinx theme deprecation.