### PR TITLE
Don't add untracked files in an adabot bundle update

### DIFF
--- a/adabot/circuitpython_bundle.py
+++ b/adabot/circuitpython_bundle.py
@@ -352,8 +352,7 @@ def commit_updates(bundle_path, update_info):
             )
         )
     message = "\n\n".join(message)
-    git.add(".")
-    git.commit(message=message)
+    git.commit("-a", message=message)
     os.chdir(working_directory)
 
 


### PR DESCRIPTION
Recently, we changed adabot to experimentally build the bundle before pushing it.

This is great, as it will hopefully avoid pushing broken bundles, which cause more problems down the line compared to just not having an updated bundle.

However, this change caused circuitpython-build-tools to create a path "build_deps" with some files inside it, and adabot *added* those files. (https://github.com/adafruit/Adafruit_CircuitPython_Bundle/commit/91e3ce1477f90e702639f188e2f839e3b2e28953)

Since an adabot bundle update should only ever change tracked files, change how git is invoked so that it does not add untracked files.