### PR TITLE
Example naming

### DIFF
--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -790,8 +790,8 @@ class LibraryValidator:
         examples_list = []
         if dirs:
 
-            lib_name_start = repo["name"].rfind("CircuitPython_") + len("CircuitPython_")
-            lib_name = repo["name"][lib_name_start:].lower()
+            lns = repo["name"].rfind("CircuitPython_") + len("CircuitPython_")
+            lib_name = repo["name"][lns:].lower()
             while dirs:
                 # loop through the results to ensure we capture files
                 # in subfolders, and add any files in the current directory
@@ -804,12 +804,16 @@ class LibraryValidator:
                     if x["type"] == "dir":
                         if x["name"].startswith(lib_name):
                             continue
-                        if x["name"].replace("_", "").startswith(lib_name.replace("_", "")):
+                        if (
+                            x["name"]
+                            .replace("_", "")
+                            .startswith(lib_name.replace("_", ""))
+                        ):
                             continue
                         dirs.append(x["url"])
                     elif x["type"] == "file":
                         examples_list.append(x)
-                
+
             if len(examples_list) < 1:
                 errors.append(ERROR_MISSING_EXAMPLE_FILES)
             else:

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -790,8 +790,10 @@ class LibraryValidator:
         examples_list = []
         if dirs:
 
-            lns = repo["name"].rfind("CircuitPython_") + len("CircuitPython_")
-            lib_name = repo["name"][lns:].lower()
+            lib_name_start = repo["name"].rfind("CircuitPython_") + len(
+                "CircuitPython_"
+            )
+            lib_name = repo["name"][lib_name_start:].lower()
             while dirs:
                 # loop through the results to ensure we capture files
                 # in subfolders, and add any files in the current directory

--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -789,6 +789,9 @@ class LibraryValidator:
         ]
         examples_list = []
         if dirs:
+
+            lib_name_start = repo["name"].rfind("CircuitPython_") + len("CircuitPython_")
+            lib_name = repo["name"][lib_name_start:].lower()
             while dirs:
                 # loop through the results to ensure we capture files
                 # in subfolders, and add any files in the current directory
@@ -797,9 +800,16 @@ class LibraryValidator:
                     errors.append(ERROR_UNABLE_PULL_REPO_EXAMPLES)
                     break
                 result_json = result.json()
-                dirs.extend([x["url"] for x in result_json if x["type"] == "dir"])
-                examples_list.extend([x for x in result_json if x["type"] == "file"])
-
+                for x in result_json:
+                    if x["type"] == "dir":
+                        if x["name"].startswith(lib_name):
+                            continue
+                        if x["name"].replace("_", "").startswith(lib_name.replace("_", "")):
+                            continue
+                        dirs.append(x["url"])
+                    elif x["type"] == "file":
+                        examples_list.append(x)
+                
             if len(examples_list) < 1:
                 errors.append(ERROR_MISSING_EXAMPLE_FILES)
             else:
@@ -813,9 +823,9 @@ class LibraryValidator:
                     or have additional underscores separating the repo name.
                     """
                     file_names = set()
-                    file_names.add(file_name[9:])
+                    file_names.add(file_name)
 
-                    name_split = file_name[9:].split("_")
+                    name_split = file_name.split("_")
                     name_rebuilt = "".join(
                         (part for part in name_split if ".py" not in part)
                     )
@@ -825,15 +835,12 @@ class LibraryValidator:
 
                     return any(name.startswith(repo_name) for name in file_names)
 
-                lib_name_start = repo["name"].rfind("CircuitPython_") + 14
-                lib_name = repo["name"][lib_name_start:].lower()
-
                 all_have_name = True
                 simpletest_exists = False
                 for example in examples_list:
                     if example["name"].endswith(".py"):
                         check_lib_name = __check_lib_name(
-                            lib_name, example["path"].lower()
+                            lib_name, example["name"].lower()
                         )
                         if not check_lib_name:
                             all_have_name = False


### PR DESCRIPTION

In trying to understand the example naming rules based on the https://circuitpython.org/contributing/library-infrastructure-issues page and the Good First Issue to begin contributing.  I ran across these repos in the list of _missing sensor/library name:_. These look to be false positives since the names in the examples directories match the naming description on the https://circuitpython.org/contributing/library-infrastructure-issues page 

https://github.com/adafruit/Adafruit_CircuitPython_Requests 
the examples directory consists of more directories, however each directory contains correctly named files, i.e. requests_xxx.py
https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI
here there is a mix of directories and files, although again all the example .py files are correctly named.
https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_Layout
again flagged although all naming appears correct.

Looking at the code in adabot I can see why these are getting flagged and it is a pretty simple fix to make this work accordingly.  However after testing the previous three now passed but these new ones now failed:
https://github.com/adafruit/Adafruit_CircuitPython_TestRepo
This one is interesting because the repo says it exists to test adabot, and the naming used is example directory named testrepo_xxx but it seems the content of the directory does not conform to the naming rule of testrepo_xxx.py.
https://github.com/adafruit/Adafruit_CircuitPython_Radial_Controller
This one too has directories named radial_controller_xxx containing anything goes .py files.

So based on what was in place and the current code in adabot circuitpython_library_validators I am proposing enhancing the example file naming with the following:

1. Each Repo in the set of repos within the adafruit organization named Adafruit_CircuitPython_SENSORLIBRARYNAME should have an examples directory at the top level of the repo.
2. Each python file (.py extension) within the examples directory should be named with the SENSORLIBRARYNAME as the initial part of the file name separated by an underscore ("_").   i.e SENSORLIBRARYNAME_coolexample.py.
3. Each top level example directory is expected to contain at least one simple test file with the name of SENSORLIBRARYNAME_simpletest.py
4. The examples directory may contain other directories.  for each of these directories if the directory name begins with SENSORLIBRARYNAME_ then the directory is assumed to contain a self consistent set of files that demonstrate some example of the SENSOR or LIBRARY and the contents of the directory are not checked for naming conventions.
5. If a subdirectory under examples is not named  SENSORLIBRARYNAME_ as the initial part of the directory name then the contents of that directory are assumed to follow the naming conventions as described in 2, for the top level examples directory.
6. SENSORLIBRARYNAME directories may be snake cased i.e SENSOR_LIBRARY_NAME as underscores are stripped from directory names and file names for SENSORLIBRARYNAME comparisons

Previous to this change 
https://github.com/adafruit/Adafruit_CircuitPython_Requests
https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI
https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_Layout

all failed the "Example file(s) missing sensor/library name"
even though to outward appearances they appeared correct

this change reduces the "Example file(s) missing sensor/library name" count from 20 to 17. Which removes the 3 named above.

I tested these changes locally by running adabot previous to the change and post change

This is the current code and it's output
 python3 -m adabot.circuitpython_libraries --validator validate_contents -o original.txt -e 100
[original.txt](https://github.com/user-attachments/files/18185877/original.txt)

This is the modified code and it's output
 python3 -m adabot.circuitpython_libraries --validator validate_contents -o mod.txt -e 100
[mod.txt](https://github.com/user-attachments/files/18186636/mod.txt)

Now I recognize that I am some newbie stranger coming poking around in what is clearly a central tool to your SDLC.  But it seems that codifying these naming conventions lets you add tooling that can expect a consistent view of the library directory structures.  For example I noted that circup has some recent initial work to add the ability to work with deploying example code to either target hardware or mirrored directories.  Although, it seems it can only deal with single files currently.  But with some consistent example naming it could deploy entire example projects consisting of several directories or files or modules quite easily.
