### PR TITLE
Automate community bundle list

### DIFF
--- a/adabot/circuitpython_bundle.py
+++ b/adabot/circuitpython_bundle.py
@@ -269,6 +269,16 @@ def repo_remote_url(repo_path):
 
 def update_bundle(bundle_path):
     """Process all libraries in the bundle, and update their version if necessary."""
+
+    if (
+        "Adafruit_CircuitPython_Bundle" not in bundle_path
+        and "CircuitPython_Community_Bundle" not in bundle_path
+    ):
+        raise ValueError(
+            "bundle_path must be for "
+            "Adafruit_CircuitPython_Bundle or CircuitPython_Community_Bundle"
+        )
+
     working_directory = os.path.abspath(os.getcwd())
     os.chdir(bundle_path)
     git.submodule("foreach", "git", "fetch")
@@ -312,12 +322,15 @@ def update_bundle(bundle_path):
     os.chdir(working_directory)
     lib_list_updates = check_lib_links_md(bundle_path)
     if lib_list_updates:
+        if "Adafruit_CircuitPython_Bundle" in bundle_path:
+            listfile_name = "circuitpython_library_list.md"
+            bundle_url = "https://github.com/adafruit/Adafruit_CircuitPython_Bundle/"
+        elif "CircuitPython_Community_Bundle" in bundle_path:
+            listfile_name = "circuitpython_community_auto_library_list.md"
+            bundle_url = "https://github.com/adafruit/CircuitPython_Community_Bundle/"
         updates.append(
             (
-                (
-                    "https://github.com/adafruit/Adafruit_CircuitPython_Bundle/"
-                    "circuitpython_library_list.md"
-                ),
+                f"{bundle_url}{listfile_name}",  # pylint: disable=possibly-used-before-assignment
                 "NA",
                 "NA",
                 "  > Added the following libraries: {}".format(
@@ -326,18 +339,6 @@ def update_bundle(bundle_path):
             )
         )
         release_required = True
-    if update_download_stats(bundle_path):
-        updates.append(
-            (
-                (
-                    "https://github.com/adafruit/Adafruit_CircuitPython_Bundle/"
-                    "circuitpython_library_list.md"
-                ),
-                "NA",
-                "NA",
-                "  > Updated download stats for the libraries",
-            )
-        )
 
     return updates, release_required
 

--- a/adabot/circuitpython_bundle.py
+++ b/adabot/circuitpython_bundle.py
@@ -140,14 +140,19 @@ def update_download_stats(bundle_path):
 # pylint: disable=too-many-locals
 def check_lib_links_md(bundle_path):
     """Checks and updates the `circuitpython_library_list` Markdown document
-    located in the Adafruit CircuitPython Bundle.
+    located in the Adafruit CircuitPython Bundle and Community Bundle.
     """
-    if not "Adafruit_CircuitPython_Bundle" in bundle_path:
+    bundle = None
+    if "Adafruit_CircuitPython_Bundle" in bundle_path:
+        bundle = "adafruit"
+    elif "CircuitPython_Community_Bundle" in bundle_path:
+        bundle = "community"
+    else:
         return []
     submodules_list = sorted(
-        common_funcs.get_bundle_submodules(), key=lambda module: module[1]["path"]
+        common_funcs.get_bundle_submodules(bundle=bundle),
+        key=lambda module: module[1]["path"],
     )
-    submodules_list = common_funcs.get_bundle_submodules()
 
     lib_count = len(submodules_list)
     # used to generate commit message by comparing new libs to current list

--- a/adabot/circuitpython_bundle.py
+++ b/adabot/circuitpython_bundle.py
@@ -145,8 +145,10 @@ def check_lib_links_md(bundle_path):
     bundle = None
     if "Adafruit_CircuitPython_Bundle" in bundle_path:
         bundle = "adafruit"
+        listfile_name = "circuitpython_library_list.md"
     elif "CircuitPython_Community_Bundle" in bundle_path:
         bundle = "community"
+        listfile_name = "circuitpython_community_auto_library_list.md"
     else:
         return []
     submodules_list = sorted(
@@ -158,7 +160,7 @@ def check_lib_links_md(bundle_path):
     # used to generate commit message by comparing new libs to current list
     try:
         with open(
-            os.path.join(bundle_path, "circuitpython_library_list.md"), "r"
+            os.path.join(bundle_path, listfile_name), "r"
         ) as lib_list:
             read_lines = lib_list.read().splitlines()
     except OSError:
@@ -203,7 +205,7 @@ def check_lib_links_md(bundle_path):
     ]
 
     with open(
-        os.path.join(bundle_path, "circuitpython_library_list.md"), "w"
+        os.path.join(bundle_path, listfile_name), "w"
     ) as md_file:
         md_file.write("\n".join(lib_list_header))
         for line in sorted(write_drivers):

--- a/adabot/circuitpython_bundle.py
+++ b/adabot/circuitpython_bundle.py
@@ -159,9 +159,7 @@ def check_lib_links_md(bundle_path):
     lib_count = len(submodules_list)
     # used to generate commit message by comparing new libs to current list
     try:
-        with open(
-            os.path.join(bundle_path, listfile_name), "r"
-        ) as lib_list:
+        with open(os.path.join(bundle_path, listfile_name), "r") as lib_list:
             read_lines = lib_list.read().splitlines()
     except OSError:
         read_lines = []
@@ -204,9 +202,7 @@ def check_lib_links_md(bundle_path):
         "## Drivers:\n",
     ]
 
-    with open(
-        os.path.join(bundle_path, listfile_name), "w"
-    ) as md_file:
+    with open(os.path.join(bundle_path, listfile_name), "w") as md_file:
         md_file.write("\n".join(lib_list_header))
         for line in sorted(write_drivers):
             md_file.write(line + "\n")

--- a/adabot/lib/common_funcs.py
+++ b/adabot/lib/common_funcs.py
@@ -84,20 +84,32 @@ def parse_gitmodules(input_text):
     return results
 
 
-def get_bundle_submodules():
+def get_bundle_submodules(bundle="adafruit"):
     """Query Adafruit_CircuitPython_Bundle repository for all the submodules
     (i.e. modules included inside) and return a list of the found submodules.
     Each list item is a 2-tuple of submodule name and a dict of submodule
     variables including 'path' (location of submodule in bundle) and
     'url' (URL to git repository with submodule contents).
+
+    :param string bundle: Which bundle to get submodules for, 'adafruit' or 'community'.
     """
     # Assume the bundle repository is public and get the .gitmodules file
     # without any authentication or Github API usage.  Also assumes the
     # master branch of the bundle is the canonical source of the bundle release.
-    result = requests.get(
-        "https://raw.githubusercontent.com/adafruit/Adafruit_CircuitPython_Bundle/main/.gitmodules",
-        timeout=REQUESTS_TIMEOUT,
-    )
+    if bundle == "adafruit":
+        result = requests.get(
+            "https://raw.githubusercontent.com/adafruit/"
+            "Adafruit_CircuitPython_Bundle/main/.gitmodules",
+            timeout=REQUESTS_TIMEOUT,
+        )
+    elif bundle == "community":
+        result = requests.get(
+            "https://raw.githubusercontent.com/adafruit/"
+            "CircuitPython_Community_Bundle/main/.gitmodules",
+            timeout=REQUESTS_TIMEOUT,
+        )
+    else:
+        raise ValueError("Bundle must be either 'adafruit' or 'community'")
     if result.status_code != 200:
         # output_handler("Failed to access bundle .gitmodules file from GitHub!", quiet=True)
         raise RuntimeError("Failed to access bundle .gitmodules file from GitHub!")


### PR DESCRIPTION
@ladyada 

Resolves: https://github.com/adafruit/CircuitPython_Community_Bundle/issues/118

I tried to test this as best as possible, however all of it is kicked off by a higher level auto cron task that includes the releasing so I can only validate the smaller components easily. 

I tested the updated list md generating code locally for both community bundle and adafruit bundle and the files seem good to me. 

My understanding of the way the cron task works is the next run after this is merged will create and push `circuitpython_community_auto_library_list.md` into the Community bundle repo.  That file will get updated each time the task runs with any changes to the bundle. 

I made it a separate file with "auto" in the name because it compares to the existing content of the file and the format differs between the auto generated one and the manual one that exists in the community bundle. Once we have the content of this file we can paste it into `circuitpython_community_library_list.md` once replacing the manually written content and we can remove "auto" from the name of the file here at the same time to complete the transition fully. 

This seemed like the safest way to migrate to the automated file to me so that we get a chance to look at the real generated list in the repo and verify it's good before making it automatically overwrite the old one.



