### PR TITLE
adding patch for sphinx configuration in rtd.yaml

### DIFF
--- a/patches/0001-add-sphinx-configuration-to-rtd.yaml.patch
+++ b/patches/0001-add-sphinx-configuration-to-rtd.yaml.patch
@@ -1,0 +1,26 @@
+From 0e4e3ab23acf83d546be3e0dd8cb47137034a32c Mon Sep 17 00:00:00 2001
+From: foamyguy <foamyguy@gmail.com>
+Date: Tue, 14 Jan 2025 11:32:34 -0600
+Subject: [PATCH] add sphinx configuration to rtd.yaml
+
+---
+ .readthedocs.yaml | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/.readthedocs.yaml b/.readthedocs.yaml
+index 33c2a61..88bca9f 100644
+--- a/.readthedocs.yaml
++++ b/.readthedocs.yaml
+@@ -8,6 +8,9 @@
+ # Required
+ version: 2
+ 
++sphinx:
++  configuration: docs/conf.py
++
+ build:
+   os: ubuntu-20.04
+   tools:
+-- 
+2.48.0
+


### PR DESCRIPTION
this addresses the fact that rtd.yaml files lacking sphinx configuration are being deprecated: https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

The same change in cookiecutter is PR'd here: https://github.com/adafruit/cookiecutter-adafruit-circuitpython/pull/246


https://github.com/adafruit/Adafruit_CircuitPython_MPU6050/pull/40 draft is opened to confirm that actions are all good. This was the library / branch that the patch file was created from. 