### PR TITLE
RTD results can cause exception

### DIFF
--- a/adabot/lib/circuitpython_library_validators.py
+++ b/adabot/lib/circuitpython_library_validators.py
@@ -975,9 +975,10 @@ class LibraryValidator:
 
         # Return the results of the latest run
         doc_build_results = json_response.get("results")
-        if doc_build_results is None:
+        if doc_build_results is None or not doc_build_results:
             errors.append(ERROR_RTD_FAILED_TO_LOAD_BUILD_STATUS_RTD_UNEXPECTED_RETURN)
             return errors
+
         result = doc_build_results[0].get("success")
         time.sleep(3)
         if not result:


### PR DESCRIPTION
The Read the docs get builds API can return an empty results set. 

`{
    "count": 0,
    "next": null,
    "previous": null,
    "results": []
}`

This causes an exception in the validator due to no check for empty set.

This simple change checks and handles that empty set

This was the cause of the bulk of the _A programmatic error occurred_ in the Library Infrastructure report