### PR TITLE
JSON response exception handling & update actions versions

### DIFF
--- a/.github/workflows/bundle_cron.yml
+++ b/.github/workflows/bundle_cron.yml
@@ -29,7 +29,7 @@ jobs:
     if: startswith(github.repository, 'adafruit/')
     steps:
     - name: Set up Python 3.12
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.12
     - name: Load contributor cache
@@ -40,7 +40,7 @@ jobs:
     - name: Versions
       run: |
         python3 --version
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Install deps

--- a/.github/workflows/learn_cron.yml
+++ b/.github/workflows/learn_cron.yml
@@ -26,7 +26,7 @@ jobs:
     # default branches).
     if: ${{ (github.repository_owner == 'adafruit') }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: ${{ github.repository_owner }}/Adafruit_Learning_System_Guides
         token: ${{ secrets.ADABOT_GITHUB_ACCESS_TOKEN }}

--- a/.github/workflows/reports_cron.yml
+++ b/.github/workflows/reports_cron.yml
@@ -37,14 +37,14 @@ jobs:
       BIGQUERY_PRIVATE_KEY: ${{ secrets.BIGQUERY_PRIVATE_KEY }}
       BIGQUERY_CLIENT_EMAIL: ${{ secrets.BIGQUERY_CLIENT_EMAIL }}
     steps:
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.11
       - name: Versions
         run: |
           python3 --version
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,13 +26,13 @@ jobs:
     if: startswith(github.repository, 'adafruit/')
     steps:
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3
     - name: Versions
       run: |
         python3 --version
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Install deps

--- a/adabot/github_requests.py
+++ b/adabot/github_requests.py
@@ -4,6 +4,7 @@
 
 """Wrapper for GitHub requests."""
 
+import types
 from base64 import b64encode
 import datetime
 import functools
@@ -57,6 +58,22 @@ def _fix_kwargs(kwargs):
     return kwargs
 
 
+def _safe_response_json(self):
+    """
+    overridden response.json() function that will catch JSONDecodeError
+    log it but try to continue on afterward.
+    """
+    try:
+        return self.original_json()
+    except requests.exceptions.JSONDecodeError:
+        exception_text = traceback.format_exc()
+        if "ADABOT_GITHUB_ACCESS_TOKEN" in os.environ:
+            exception_text = exception_text.replace(
+                os.environ["ADABOT_GITHUB_ACCESS_TOKEN"], "[secure]"
+            )
+        logging.warning("%s", exception_text)
+    return {}
+
 def request(method, url, **kwargs):
     """Processes request for `url`."""
     try:
@@ -107,6 +124,8 @@ def request(method, url, **kwargs):
             logging.info("Sleeping %s seconds", reset_diff.seconds + 60)
             time.sleep(reset_diff.seconds + 60)
 
+    response.original_json = response.json
+    response.json = types.MethodType(_safe_response_json, response)
     return response
 
 

--- a/adabot/github_requests.py
+++ b/adabot/github_requests.py
@@ -74,6 +74,7 @@ def _safe_response_json(self):
         logging.warning("%s", exception_text)
     return {}
 
+
 def request(method, url, **kwargs):
     """Processes request for `url`."""
     try:


### PR DESCRIPTION
Override `response.json()` with a version that catches JSON decode errors, logs them, and attempts to continue on. 

Depending on which part of the code called `json()` this could still halt the action, but it seems many places check `if "key" in response_data` and should be able to continue running in the event of a decode error on a single request in the middle of compiling a report. 

Also updated versions of: 
- python in the reports container
- actions checkout and setup-python