### PR TITLE
Add patch for pre-commit hooks and license specification

### DIFF
--- a/patches/26MAR2026-Update-License-Specification.patch
+++ b/patches/26MAR2026-Update-License-Specification.patch
@@ -1,0 +1,25 @@
+From 7b9aaa02672ca56c724a3892f95060d0125ceb39 Mon Sep 17 00:00:00 2001
+From: Alec Delaney <tekktrik@gmail.com>
+Date: Thu, 26 Mar 2026 23:01:11 -0400
+Subject: [PATCH] Update license specification
+
+---
+ pyproject.toml | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index e8fa364..02c2b00 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -34,3 +34,3 @@ keywords = [
+ ]
+-license = {text = "MIT"}
++license = "MIT"
+ classifiers = [
+@@ -40,3 +40,2 @@ classifiers = [
+     "Topic :: System :: Hardware",
+-    "License :: OSI Approved :: MIT License",
+     "Programming Language :: Python :: 3",
+-- 
+2.53.0
+

--- a/patches/26MAR2026-Update-pre-commit-Hooks.patch
+++ b/patches/26MAR2026-Update-pre-commit-Hooks.patch
@@ -1,0 +1,33 @@
+From eb8b2e4e9b5949d97c664df3278f7782adc348c3 Mon Sep 17 00:00:00 2001
+From: Alec Delaney <tekktrik@gmail.com>
+Date: Thu, 26 Mar 2026 22:56:35 -0400
+Subject: [PATCH] Update pre-commit hooks (except ruff)
+
+---
+ .pre-commit-config.yaml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/.pre-commit-config.yaml b/.pre-commit-config.yaml
+index ff19dde..59304f3 100644
+--- a/.pre-commit-config.yaml
++++ b/.pre-commit-config.yaml
+@@ -4,7 +4,7 @@
+ 
+ repos:
+   - repo: https://github.com/pre-commit/pre-commit-hooks
+-    rev: v4.5.0
++    rev: v6.0.0
+     hooks:
+       - id: check-yaml
+       - id: end-of-file-fixer
+@@ -16,6 +16,6 @@ repos:
+       - id: ruff
+         args: ["--fix"]
+   - repo: https://github.com/fsfe/reuse-tool
+-    rev: v3.0.1
++    rev: v6.2.0
+     hooks:
+       - id: reuse
+-- 
+2.53.0
+

--- a/patches/26MAR2026-Update-ruff-pre-commit.patch
+++ b/patches/26MAR2026-Update-ruff-pre-commit.patch
@@ -1,0 +1,27 @@
+From 7c63930a14ffd4c7e054dd831063326b15f82140 Mon Sep 17 00:00:00 2001
+From: Alec Delaney <tekktrik@gmail.com>
+Date: Thu, 26 Mar 2026 22:58:12 -0400
+Subject: [PATCH] Update ruff pre-commit hook
+
+---
+ .pre-commit-config.yaml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/.pre-commit-config.yaml b/.pre-commit-config.yaml
+index 59304f3..0ec3052 100644
+--- a/.pre-commit-config.yaml
++++ b/.pre-commit-config.yaml
+@@ -9,9 +9,9 @@ repos:
+       - id: check-yaml
+       - id: end-of-file-fixer
+       - id: trailing-whitespace
+   - repo: https://github.com/astral-sh/ruff-pre-commit
+-    rev: v0.3.4
++    rev: v0.15.8
+     hooks:
+       - id: ruff-format
+       - id: ruff
+         args: ["--fix"]
+-- 
+2.53.0
+


### PR DESCRIPTION
PLEASE APPROVE WITH https://github.com/adafruit/cookiecutter-adafruit-circuitpython/pull/261

Part of https://github.com/adafruit/adabot/issues/407

Applies a patch that updates the pre-commit hooks (importantly `reuse`) as well as fixes the license specification in `pyproject.toml`.  I dry-ran the patch and here are the currently expected results:

```shell
> python -m adabot.circuitpython_library_patches --dry-run --local -p 19MAR2026-Pre-Commit-Hooks-License.patch 
.... Beginning Patch Updates ....
.... Working directory: /home/tekktrik/Documents/Repositories/adabot
.... Library directory: /home/tekktrik/Documents/Repositories/adabot/.libraries/
.... Patches directory: /home/tekktrik/Documents/Repositories/adabot/patches/
.... Deleting any previously cloned libraries
.... Running Patch Checks On 406 Repos ....
   . Skipping Adafruit_CircuitPython_MFRC630: No such file or directory
   . Skipping Adafruit_CircuitPython_AT86RF233: No such file or directory
   . Skipping Adafruit_CircuitPython_Debug_Bus_Device: No such file or directory
   . Skipping Adafruit_CircuitPython_Debug_SPI: No such file or directory
   . Skipping Adafruit_CircuitPython_MachXO: No such file or directory
   . Skipping Adafruit_CircuitPython_JTAG: No such file or directory
   . Skipping Adafruit_CircuitPython_MCU_Flasher: patch does not apply
   . Skipping Adafruit_CircuitPython_Debug_Probe: patch does not apply
   . Skipping Adafruit_CircuitPython_Register_SPI: patch does not apply
   . Skipping Adafruit_CircuitPython_BLE_Creation: patch does not apply
   . Skipping Adafruit_CircuitPython_TestRepo: patch does not apply
   . Skipping Adafruit_CircuitPython_Fake_BME280: patch does not apply
   . Skipping Adafruit_CircuitPython_Base64_Stream: patch does not apply
   . Skipping Adafruit_CircuitPython_ICN6211: patch does not apply
   . Skipping Adafruit_CircuitPython_MiniMQTT: patch does not apply
   . Skipping Adafruit_CircuitPython_AS7343: patch does not apply
   . Skipping Adafruit_CircuitPython_STCC4: patch does not apply
   . Skipping Adafruit_CircuitPython_TCS3430: patch does not apply
   . Skipping Adafruit_CircuitPython_Bundle: No such file or directory
.... Patch Updates Completed ....
.... Patches Applied: 385
.... Patches Skipped: 19
.... Patches Failed: 2 

.... Patch Check Failure Report ....
>> Repo: Adafruit_CircuitPython_ULP_Blink       Patch: 19MAR2026-Pre-Commit-Hooks-License.patch
   Error: pyproject.toml: No such file or directory 
>> Repo: Adafruit_CircuitPython_Intellikeys     Patch: 19MAR2026-Pre-Commit-Hooks-License.patch
   Error: pyproject.toml: No such file or directory 


.... Patch Apply Failure Report ....
No Failures
```