### PR TITLE
Fix stray slash

### DIFF
--- a/adabot/circuitpython_bundle.py
+++ b/adabot/circuitpython_bundle.py
@@ -181,7 +181,7 @@ def check_lib_links_md(bundle_path):
         docs_name = ""
         docs_link = common_funcs.get_docs_link(bundle_path, submodule)
         if docs_link:
-            docs_name = f" ([Docs]({docs_link}))"  # pylint: disable=anomalous-backslash-in-string
+            docs_name = f" ([Docs]({docs_link}))"
         title = url_name.replace("_", " ")
         list_line = "* [{0}]({1}){2}{3}".format(title, url, pypi_name, docs_name)
         if list_line not in read_lines:

--- a/adabot/circuitpython_bundle.py
+++ b/adabot/circuitpython_bundle.py
@@ -181,7 +181,7 @@ def check_lib_links_md(bundle_path):
         docs_name = ""
         docs_link = common_funcs.get_docs_link(bundle_path, submodule)
         if docs_link:
-            docs_name = f" \([Docs]({docs_link}))"  # pylint: disable=anomalous-backslash-in-string
+            docs_name = f" ([Docs]({docs_link}))"  # pylint: disable=anomalous-backslash-in-string
         title = url_name.replace("_", " ")
         list_line = "* [{0}]({1}){2}{3}".format(title, url, pypi_name, docs_name)
         if list_line not in read_lines:


### PR DESCRIPTION
I had a CI (pylint, I believe?) run warn about this, and after checking how this renders I believe it is just a stray slash.  Removing it doesn't change the inteded rendering on the GitHub page:

https://github.com/adafruit/Adafruit_CircuitPython_Bundle/blob/main/circuitpython_library_list.md