### PR TITLE
circuitpython_libraries: per-repo Blinka open-issue counts

### DIFF
--- a/adabot/circuitpython_libraries.py
+++ b/adabot/circuitpython_libraries.py
@@ -322,7 +322,21 @@ def run_library_checks(validators, kw_args, error_depth):
         logger.info("  * %s", pull_request)
     print_issue_overview(blinka_insights)
     logger.info("* %s open issues", len(blinka_insights["open_issues"]))
-    logger.info("  * https://github.com/adafruit/Adafruit_Blinka/issues")
+    blinka_issue_counts = {}
+    for issue_link in blinka_insights["open_issues"]:
+        # issue_link is like
+        # "https://github.com/adafruit/<repo>/issues/<n> (Open <d> days)"
+        match = re.search(r"github\.com/adafruit/([^/]+)/issues/", issue_link)
+        if match:
+            blinka_issue_counts[match.group(1)] = (
+                blinka_issue_counts.get(match.group(1), 0) + 1
+            )
+    for repo_name in sorted(blinka_issue_counts):
+        logger.info(
+            "  * https://github.com/adafruit/%s/issues (%s)",
+            repo_name,
+            blinka_issue_counts[repo_name],
+        )
     logger.info("* Number of supported boards: %s", blinka_funcs.board_count())
 
 


### PR DESCRIPTION
## What

The Blinka section of the weekly state-of-CircuitPython report prints an aggregate "N open issues" line that sums every repo in `blinka_repos`, then drops a single URL underneath pointing at `adafruit/Adafruit_Blinka`. That format makes the count look like it's about one repo when it actually spans all ten.

This PR replaces the single link with an indented per-repo list of issue-tracker URLs with the open-issue count in parentheses, sorted by repo name. Zero-count repos are omitted so the list stays focused on the repos that actually need triage. The total line above is unchanged for continuity with prior reports.

## Example output

```
* 84 open issues
  * https://github.com/adafruit/Adafruit_Blinka/issues (38)
  * https://github.com/adafruit/Adafruit_Blinka_Displayio/issues (10)
  * https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/issues (10)
  * https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_rp1pio/issues (13)
  * https://github.com/adafruit/Adafruit_Blinka_bleio/issues (10)
  * https://github.com/adafruit/Adafruit_Python_Extended_Bus/issues (1)
  * https://github.com/adafruit/Adafruit_Python_PlatformDetect/issues (2)
```

## How

Per-repo counts are derived by parsing the existing `blinka_insights["open_issues"]` entries with a small regex against the GitHub URL each entry already contains. No extra API calls; no change to data collection or to how issues are counted toward the total.

## Notes

- `pre-commit run --all-files` clean (black, pylint, reuse, trailing-whitespace, end-of-file-fixer).